### PR TITLE
Tuesday updates!

### DIFF
--- a/bat-utils/lib/runtime-currency.js
+++ b/bat-utils/lib/runtime-currency.js
@@ -294,7 +294,7 @@ const monitor3 = (config, runtime) => {
 
 const maintenance = async (config, runtime) => {
   const now = underscore.now()
-  let results, tickers
+  let fxrates, results, tickers
 
   if (flatlineP) {
     debug('maintenance', { message: 'no trades reported' })
@@ -328,9 +328,10 @@ const maintenance = async (config, runtime) => {
   }
 
   if (singleton.oxr) {
-    try { singleton.fxrates = await singleton.oxr.latest() } catch (ex) {
+    try { fxrates = await singleton.oxr.latest() } catch (ex) {
       runtime.captureException(ex)
     }
+    if ((fxrates) && (fxrates.rates)) singleton.fxrates = fxrates
   }
 
   try { tickers = await inkblot(config, runtime) } catch (ex) {

--- a/bat-utils/lib/runtime-wallet.js
+++ b/bat-utils/lib/runtime-wallet.js
@@ -311,6 +311,7 @@ Wallet.providers.uphold = {
       preferredCurrency: currency,
       availableCurrencies: currencies
     }
+    if (result.authorized) result.id = user.id
 
     return result
   }

--- a/eyeshade/controllers/owners.js
+++ b/eyeshade/controllers/owners.js
@@ -198,6 +198,7 @@ v1.getWallet = {
       try {
         if (provider) result.wallet = await runtime.wallet.status(entry)
         if (result.wallet) {
+          result.wallet = underscore.pick(result.wallet, [ 'provider', 'authorized', 'preferredCurrency', 'availableCurrencies' ])
           rates = result.rates
 
           underscore.union([ result.wallet.preferredCurrency ], result.wallet.availableCurrencies).forEach((currency) => {

--- a/eyeshade/controllers/publishers.js
+++ b/eyeshade/controllers/publishers.js
@@ -331,6 +331,7 @@ v2.getWallet = {
       try {
         if (provider) result.wallet = await runtime.wallet.status(entry)
         if (result.wallet) {
+          result.wallet = underscore.pick(result.wallet, [ 'provider', 'authorized', 'preferredCurrency', 'availableCurrencies' ])
           rates = result.rates
 
           underscore.union([ result.wallet.preferredCurrency ], result.wallet.availableCurrencies).forEach((currency) => {

--- a/eyeshade/controllers/reports.js
+++ b/eyeshade/controllers/reports.js
@@ -75,7 +75,7 @@ v1.publisher.contributions = {
 
   auth: {
     strategy: 'session',
-    scope: [ 'ledger' ],
+    scope: [ 'ledger', 'QA' ],
     mode: 'required'
   },
 
@@ -117,7 +117,7 @@ v1.publishers.contributions = {
 
   auth: {
     strategy: 'session',
-    scope: [ 'ledger' ],
+    scope: [ 'ledger', 'QA' ],
     mode: 'required'
   },
 
@@ -165,7 +165,7 @@ v1.publisher.settlements = {
 
   auth: {
     strategy: 'session',
-    scope: [ 'ledger' ],
+    scope: [ 'ledger', 'QA' ],
     mode: 'required'
   },
 
@@ -204,7 +204,7 @@ v1.publishers.settlements = {
 
   auth: {
     strategy: 'session',
-    scope: [ 'ledger' ],
+    scope: [ 'ledger', 'QA' ],
     mode: 'required'
   },
 
@@ -248,7 +248,7 @@ v1.publisher.statements = {
 
   auth: {
     strategy: 'session',
-    scope: [ 'ledger' ],
+    scope: [ 'ledger', 'QA' ],
     mode: 'required'
   },
 
@@ -285,7 +285,7 @@ v1.publishers.statements = {
 
   auth: {
     strategy: 'session',
-    scope: [ 'ledger' ],
+    scope: [ 'ledger', 'QA' ],
     mode: 'required'
   },
 
@@ -324,7 +324,7 @@ v2.publishers.statements = {
 
   auth: {
     strategy: 'session',
-    scope: [ 'ledger' ],
+    scope: [ 'ledger', 'QA' ],
     mode: 'required'
   },
 
@@ -452,7 +452,7 @@ v1.surveyors.contributions = {
 
   auth: {
     strategy: 'session',
-    scope: [ 'ledger' ],
+    scope: [ 'ledger', 'QA' ],
     mode: 'required'
   },
 

--- a/ledger/controllers/publisher.js
+++ b/ledger/controllers/publisher.js
@@ -27,7 +27,10 @@ const rulesetEntry = async (request, runtime) => {
   if ((!entry) || (entry.version.indexOf(version) !== 0)) {
     if (entry) rulesets.remove({ rulesetId: rulesetId })
 
-    entry = { ruleset: batPublisher.ruleset, version: version }
+    entry = {
+      ruleset: typeof batPublisher.ruleset === 'function' ? batPublisher.ruleset() : batPublisher.ruleset,
+      version: version
+    }
   }
 
   return entry
@@ -658,14 +661,17 @@ module.exports.initialize = async (debug, runtime) => {
   ])
 
   entry = await rulesets.findOne({ rulesetId: rulesetId })
-  validity = Joi.validate(entry ? entry.ruleset : batPublisher.ruleset, batPublisher.schema)
+  validity = Joi.validate(entry ? entry.ruleset
+                                : typeof batPublisher.ruleset === 'function' ? batPublisher.ruleset() : batPublisher.ruleset,
+                          batPublisher.schema)
   if (validity.error) throw new Error(validity.error)
 
   batPublisher.getRules((err, rules) => {
     let validity
     if (err) throw new Error(err)
 
-    if ((!rules) || (underscore.isEqual(batPublisher.ruleset, rules))) return
+    if ((!rules) || (underscore.isEqual(typeof batPublisher.ruleset === 'function' ? batPublisher.ruleset() : batPublisher.ruleset,
+                                        rules))) return
 
     validity = Joi.validate(rules, batPublisher.schema)
     if (validity.error) throw new Error(validity.error)

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "babel-cli": "^6.26.0",
     "babel-preset-stage-2": "^6.24.1",
     "bat-balance": "^1.0.3",
-    "bat-publisher": "^1.3.1",
+    "bat-publisher": "^2.0.0",
     "bell": "8.7.0",
     "bignumber.js": "^4.0.4",
     "bitcoinjs-lib": "^3.2.0",


### PR DESCRIPTION
1. Test for incomplete forages
2. Return userId for uphold publishers to be used in contributions
batches.
3. Allow ‘QA’ group read-only access to all reports
4. Remove deprecated `address` field from reports
5. Support `bat-publishers@2.0.0`