### PR TITLE
Add optional $IP_QA_WHITELIST

### DIFF
--- a/bat-utils/lib/hapi-auth-whitelist.js
+++ b/bat-utils/lib/hapi-auth-whitelist.js
@@ -24,7 +24,7 @@ const internals = {
 exports.authorizedP = (ipaddr) => {
   if ((authorizedAddrs) &&
         ((authorizedAddrs.indexOf(ipaddr) !== -1) ||
-         (underscore.find(authorizedBlocks, (block) => { block.contains(ipaddr) })))) return true
+         (underscore.find(authorizedBlocks, (block) => { return block.contains(ipaddr) })))) return true
 }
 
 exports.ipaddr = (request) => {
@@ -37,7 +37,7 @@ exports.authenticate = (request, reply) => {
 
   if ((authorizedAddrs) &&
         (authorizedAddrs.indexOf(ipaddr) === -1) &&
-        (!underscore.find(authorizedBlocks, (block) => { block.contains(ipaddr) }))) return reply(boom.notAcceptable())
+        (!underscore.find(authorizedBlocks, (block) => { return block.contains(ipaddr) }))) return reply(boom.notAcceptable())
 
   try {
     result = reply.continue({ credentials: { ipaddr: ipaddr } })

--- a/bat-utils/lib/hapi-server.js
+++ b/bat-utils/lib/hapi-server.js
@@ -83,7 +83,7 @@ const Server = async (options, runtime) => {
 
             if ((graylist.authorizedAddrs) &&
                 ((graylist.authorizedAddrs.indexOf(ipaddr) !== -1) ||
-                 (underscore.find(graylist.authorizedBlocks, (block) => { block.contains(ipaddr) })))) {
+                 (underscore.find(graylist.authorizedBlocks, (block) => { return block.contains(ipaddr) })))) {
               return { limit: Number.MAX_SAFE_INTEGER, window: 1 }
             }
 

--- a/bat-utils/lib/runtime-currency.js
+++ b/bat-utils/lib/runtime-currency.js
@@ -304,13 +304,6 @@ const maintenance = async (config, runtime) => {
   const now = underscore.now()
   let fxrates, results, tickers
 
-  if (flatlineP) {
-    debug('maintenance', { message: 'no trades reported' })
-    runtime.captureException(new Error('maintenance reports flatline'))
-    process.exit(0)
-  }
-  flatlineP = true
-
   if (config.helper) {
     try {
       results = await retrieve(runtime, config.helper.url + '/v1/rates', {
@@ -320,7 +313,6 @@ const maintenance = async (config, runtime) => {
         },
         useProxyP: true
       }, Currency.prototype.schemas.rates)
-      flatlineP = false
     } catch (ex) {
       runtime.captureException(ex)
     }
@@ -334,6 +326,13 @@ const maintenance = async (config, runtime) => {
 
     return
   }
+
+  if (flatlineP) {
+    debug('maintenance', { message: 'no trades reported' })
+    runtime.captureException(new Error('maintenance reports flatline'))
+    process.exit(0)
+  }
+  flatlineP = true
 
   if (singleton.oxr) {
     try { fxrates = await singleton.oxr.latest() } catch (ex) {


### PR DESCRIPTION
If set, it contains a comma-separated list of either IP addresses or IP
blocks that list those IPs that are allowed to use the `GET
/v1/{promotions,grants} endpoints.

Also, fix a big in handing IP blocks for the other whitelist/graylist
code

Finally, fix an _unrelated_ bug if the helper server is unavailable
after startup.