### PR TITLE
fix balance comparison during grant redemption

### DIFF
--- a/bat-utils/lib/runtime-wallet.js
+++ b/bat-utils/lib/runtime-wallet.js
@@ -160,7 +160,7 @@ Wallet.prototype.redeem = async function (info, txn, signature) {
 
   if (!info.balances) info.balances = await this.balances(info)
   balance = new BigNumber(info.balances.confirmed)
-  desired = new BigNumber(txn.denomination.amount)
+  desired = new BigNumber(txn.denomination.amount).times(this.currency.alt2scale(info.altcurrency))
   if (balance.greaterThanOrEqualTo(desired)) return
 
   payload = {


### PR DESCRIPTION
balance is denominated in probi, however amount is within an Uphold transaction so it is denominated in nominal units (BAT). this causes the balance comparison to go wrong when the user has some balance but still needs to redeem a grant in order to fulfill the settlement amount.