### PR TITLE
Report fixups

### DIFF
--- a/bat-utils/lib/extras-utils.js
+++ b/bat-utils/lib/extras-utils.js
@@ -9,4 +9,13 @@ exports.extractJws = (jws) => {
   return JSON.parse(buf.toString('utf8'))
 }
 
+// courtesy of https://stackoverflow.com/questions/31649362/json-stringify-and-unicode-characters#31652607
+exports.utf8ify = (data) => {
+  if (typeof data !== 'string') data = JSON.stringify(data, null, 2)
+
+  return data.replace(/[\u007F-\uFFFF]/g, (c) => {
+    return '\\u' + ('0000' + c.charCodeAt(0).toString(16)).substr(-4)
+  })
+}
+
 module.exports = exports

--- a/bat-utils/lib/runtime-database.js
+++ b/bat-utils/lib/runtime-database.js
@@ -52,9 +52,9 @@ Database.prototype.middleware = (context) => {
           if (result._id) values = result._id
           else if (Array.isArray(result) && (typeof result.length === 'number')) {
             values = []
-            result.forEach((entry) => { if (entry._id) values.push(entry._id) })
+            if (result.length < 4) { result.forEach((entry) => { if (entry._id) values.push(entry._id) }) }
             if (result.length === values.length) values = stringify(values)
-            else values = result.length + ' result' + (result.length === 1 ? 's' : '')
+            else values = result.length + ' result' + (result.length !== 1 ? 's' : '')
           }
         }
 

--- a/eyeshade/controllers/owners.js
+++ b/eyeshade/controllers/owners.js
@@ -355,7 +355,7 @@ v1.getStatement = {
       await runtime.queue.send(debug, 'report-publishers-statements',
                                underscore.defaults({ reportId: reportId, reportURL: reportURL, owner: owner },
                                                    request.query,
-                                                   { authority: 'automated', rollup: true, summary: false }))
+                                                   { authority: 'automated', rollup: false, summary: false }))
       reply({ reportURL: reportURL })
     }
   },

--- a/eyeshade/workers/publishers.js
+++ b/eyeshade/workers/publishers.js
@@ -4,7 +4,9 @@ const underscore = require('underscore')
 const reports = require('./reports.js')
 const create = reports.create
 const publish = reports.publish
-const timeout = require('bat-utils').extras.utils.timeout
+const utils = require('bat-utils').extras.utils
+const utf8ify = utils.utf8ify
+const timeout = utils.timeout
 
 var exports = {}
 
@@ -71,9 +73,9 @@ exports.workers = {
 
       file = await create(runtime, 'publishers-', payload)
       if (format === 'json') {
-        await file.write(JSON.stringify(publishers, null, 2), true)
+        await file.write(utf8ify(publishers), true)
       } else {
-        try { await file.write(json2csv({ data: publishers }), true) } catch (ex) {
+        try { await file.write(utf8ify(json2csv({ data: publishers })), true) } catch (ex) {
           debug('reports', { report: 'bulk-publishers-create', reason: ex.toString() })
           file.close()
         }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "babel-cli": "^6.26.0",
     "babel-preset-stage-2": "^6.24.1",
     "bat-balance": "^1.0.3",
-    "bat-publisher": "^2.0.0",
+    "bat-publisher": "^2.0.1",
     "bell": "8.7.0",
     "bignumber.js": "^4.0.4",
     "bitcoinjs-lib": "^3.2.0",


### PR DESCRIPTION
1. When returning JSON make sure all strings are unicode-ified  as necessary.

2. When reporting database results to the logs, if over 3 results, just list the length of the result set, rather than the `_id` of each result in the set.

3. Invoke the eyeshade report generator with `rollup=false` (`rollup` makes sense only when doing reports based on a transaction-hash).

4. Use `bat-publisher@2.0.1`

NB: this PR requires on https://github.com/brave-intl/bat-publisher/pull/8