### PR TITLE
Owner model updates

### DIFF
--- a/eyeshade/controllers/owners.js
+++ b/eyeshade/controllers/owners.js
@@ -558,8 +558,8 @@ v1.getToken = {
 v1.putToken = {
   handler: (runtime) => {
     return async (request, reply) => {
-      return putToken(request, reply, runtime, null, request.params.owner, request.params.publisher,
-                      request.payload.verificationId, request.query.show_verification_status)
+      return putToken(request, reply, runtime, request.params.owner, request.params.publisher, request.payload.verificationId,
+                      request.query.show_verification_status)
     }
   },
 

--- a/eyeshade/controllers/owners.js
+++ b/eyeshade/controllers/owners.js
@@ -61,7 +61,7 @@ v1.bulk = {
   },
 
   description: 'Creates publisher entries in bulk',
-  tags: [ 'api', 'deprecated' ],
+  tags: [ 'api', 'publishers', 'deprecated' ],
 
   validate: {
     headers: Joi.object({ authorization: Joi.string().required() }).unknown(),
@@ -114,7 +114,7 @@ v2.bulk = {
   },
 
   description: 'Creates publisher entries in bulk',
-  tags: [ 'api' ],
+  tags: [ 'api', 'publishers' ],
 
   validate: {
     headers: Joi.object({ authorization: Joi.string().required() }).unknown(),
@@ -245,7 +245,7 @@ v1.unlinkPublisher = {
   },
 
   description: 'Unlinks a publisher from an owner',
-  tags: [ 'api' ],
+  tags: [ 'api', 'publishers' ],
 
   validate: {
     headers: Joi.object({ authorization: Joi.string().required() }).unknown(),
@@ -377,7 +377,7 @@ v1.getWallet = {
   },
 
   description: 'Gets information for a publisher',
-  tags: [ 'api' ],
+  tags: [ 'api', 'publishers' ],
 
   validate: {
     headers: Joi.object({ authorization: Joi.string().required() }).unknown(),
@@ -467,7 +467,7 @@ v1.putWallet = {
   },
 
   description: 'Sets information for a verified publisher',
-  tags: [ 'api' ],
+  tags: [ 'api', 'publishers' ],
 
   validate: {
     headers: Joi.object({ authorization: Joi.string().required() }).unknown(),
@@ -513,7 +513,7 @@ v1.getStatement = {
   },
 
   description: 'Generates a statement for a publisher',
-  tags: [ 'api' ],
+  tags: [ 'api', 'publishers' ],
 
   validate: {
     headers: Joi.object({ authorization: Joi.string().required() }).unknown(),
@@ -544,7 +544,7 @@ v1.getToken = {
   },
 
   description: 'Verifies a publisher claimed by an owner',
-  tags: [ 'api' ],
+  tags: [ 'api', 'publishers' ],
 
   validate: {
     params: {
@@ -581,7 +581,7 @@ v1.putToken = {
   },
 
   description: 'Gets a verification token for a publisher',
-  tags: [ 'api' ],
+  tags: [ 'api', 'publishers' ],
 
   validate: {
     headers: Joi.object({ authorization: Joi.string().required() }).unknown(),

--- a/eyeshade/controllers/owners.js
+++ b/eyeshade/controllers/owners.js
@@ -205,7 +205,7 @@ const bulk = async (request, reply, runtime, owner, info, channels) => {
        [ used by publishers ]
  */
 
-v1.deletePublisher = {
+v1.unlinkPublisher = {
   handler: (runtime) => {
     return async (request, reply) => {
       const owner = request.params.owner
@@ -606,7 +606,7 @@ module.exports.routes = [
   braveHapi.routes.async().path('/v1/owners/{owner}/statement').whitelist().config(v1.getStatement),
   braveHapi.routes.async().path('/v1/owners/{owner}/verify/{publisher}').config(v1.getToken),
   braveHapi.routes.async().put().path('/v1/owners/{owner}/verify/{publisher}').whitelist().config(v1.putToken),
-  braveHapi.routes.async().delete().path('/v1/owners/{owner}/{publisher}').whitelist().config(v1.deletePublisher)
+  braveHapi.routes.async().delete().path('/v1/owners/{owner}/{publisher}').whitelist().config(v1.unlinkPublisher)
 ]
 
 module.exports.initialize = async (debug, runtime) => {

--- a/eyeshade/controllers/owners.js
+++ b/eyeshade/controllers/owners.js
@@ -49,7 +49,7 @@ v1.bulk = {
 
       if (authorizer.ownerEmail || authorizer.ownerName) info = { email: authorizer.ownerEmail, name: authorizer.ownerName }
       providers.forEach((provider) => {
-        channels.push(underscore.extend({ channeId: provider.publisher, visible: provider.show_verification_status }, info))
+        channels.push(underscore.extend({ channelId: provider.publisher, visible: provider.show_verification_status }, info))
       })
 
       bulk(request, reply, runtime, authorizer.owner, request.payload.contactInfo, channels)

--- a/eyeshade/controllers/owners.js
+++ b/eyeshade/controllers/owners.js
@@ -115,7 +115,7 @@ v2.bulk = {
     payload: Joi.object().keys({
       ownerId: braveJoi.string().owner().required().description('the owner identity'),
       contactInfo: Joi.object().keys({
-        name: Joi.string().required().description('owner name'),
+        name: Joi.string().optional().description('owner name'),
         phone: Joi.string().regex(/^\+(?:[0-9][ -]?){6,14}[0-9]$/).optional().description('owner phone number'),
         email: Joi.string().email().required().description('owner verified email address')
       }).optional(),

--- a/eyeshade/controllers/owners.js
+++ b/eyeshade/controllers/owners.js
@@ -64,9 +64,7 @@ v1.bulk = {
   tags: [ 'api', 'deprecated' ],
 
   validate: {
-    query: {
-      access_token: Joi.string().guid().optional()
-    },
+    headers: Joi.object({ authorization: Joi.string().required() }).unknown(),
     payload: Joi.object().keys({
       authorizer: Joi.object().keys({
         owner: braveJoi.string().owner().required().description('the owner identity'),
@@ -109,9 +107,7 @@ v2.bulk = {
   tags: [ 'api' ],
 
   validate: {
-    query: {
-      access_token: Joi.string().guid().optional()
-    },
+    headers: Joi.object({ authorization: Joi.string().required() }).unknown(),
     payload: Joi.object().keys({
       ownerId: braveJoi.string().owner().required().description('the owner identity'),
       contactInfo: Joi.object().keys({
@@ -240,12 +236,10 @@ v1.unlinkPublisher = {
   tags: [ 'api' ],
 
   validate: {
+    headers: Joi.object({ authorization: Joi.string().required() }).unknown(),
     params: {
       owner: braveJoi.string().owner().required().description('the owner identity'),
       publisher: braveJoi.string().publisher().required().description('the publisher identity')
-    },
-    query: {
-      access_token: Joi.string().guid().optional()
     }
   },
 
@@ -374,11 +368,9 @@ v1.getWallet = {
   tags: [ 'api' ],
 
   validate: {
+    headers: Joi.object({ authorization: Joi.string().required() }).unknown(),
     params: { owner: braveJoi.string().owner().required().description('the owner identity') },
-    query: {
-      currency: braveJoi.string().currencyCode().optional().default('USD').description('the fiat currency'),
-      access_token: Joi.string().guid().optional()
-    }
+    query: { currency: braveJoi.string().currencyCode().optional().default('USD').description('the fiat currency') }
   },
 
   response: {
@@ -466,8 +458,7 @@ v1.putWallet = {
   tags: [ 'api' ],
 
   validate: {
-    params: { owner: braveJoi.string().owner().required().description('the owner identity') },
-    query: { access_token: Joi.string().guid().optional() },
+    headers: Joi.object({ authorization: Joi.string().required() }).unknown(),
     payload: {
       provider: Joi.string().required().description('wallet provider'),
       parameters: Joi.object().required().description('wallet parameters')
@@ -513,11 +504,11 @@ v1.getStatement = {
   tags: [ 'api' ],
 
   validate: {
+    headers: Joi.object({ authorization: Joi.string().required() }).unknown(),
     params: { owner: braveJoi.string().owner().required().description('the owner identity') },
     query: {
       starting: Joi.date().iso().optional().description('starting timestamp in ISO 8601 format'),
-      ending: Joi.date().iso().optional().description('ending timestamp in ISO 8601 format'),
-      access_token: Joi.string().guid().optional()
+      ending: Joi.date().iso().optional().description('ending timestamp in ISO 8601 format')
     }
   },
 
@@ -581,17 +572,13 @@ v1.putToken = {
   tags: [ 'api' ],
 
   validate: {
+    headers: Joi.object({ authorization: Joi.string().required() }).unknown(),
     params: {
       owner: braveJoi.string().owner().required().description('the owner identity'),
       publisher: braveJoi.string().publisher().required().description('the publisher identity')
     },
-    query: {
-      access_token: Joi.string().guid().optional(),
-      show_verification_status: Joi.boolean().optional().default(true).description('authorizes display')
-    },
-    payload: {
-      verificationId: Joi.string().guid().required().description('identity of the requestor')
-    }
+    query: { show_verification_status: Joi.boolean().optional().default(true).description('authorizes display') },
+    payload: { verificationId: Joi.string().guid().required().description('identity of the requestor') }
   },
 
   response:

--- a/eyeshade/controllers/owners.js
+++ b/eyeshade/controllers/owners.js
@@ -138,12 +138,12 @@ const bulk = async (request, reply, runtime, owner, info, channels) => {
   props = batPublisher.getPublisherProps(owner)
   if (!props) return reply(boom.notFound('no such entry: ' + owner))
 
+  if (!info) info = {}
+  if (!channels) channels = []
+
   for (let channel of channels) {
     if (!batPublisher.getPublisherProps(channel.channelId)) return reply(boom.notFound('no such entry: ' + channel.channelId))
   }
-
-  if (!info) info = {}
-  if (!channels) channels = []
 
   state = {
     $currentDate: { timestamp: { $type: 'timestamp' } },

--- a/eyeshade/controllers/publishers.js
+++ b/eyeshade/controllers/publishers.js
@@ -217,7 +217,7 @@ v2.getBalance = {
   },
 
   description: 'Gets the balance for a verified publisher',
-  tags: [ 'api' ],
+  tags: [ 'api', 'publishers' ],
 
   validate: {
     headers: Joi.object({ authorization: Joi.string().required() }).unknown(),
@@ -351,7 +351,7 @@ v2.getWallet = {
   },
 
   description: 'Gets information for a publisher',
-  tags: [ 'api' ],
+  tags: [ 'api', 'publishers' ],
 
   validate: {
     headers: Joi.object({ authorization: Joi.string().required() }).unknown(),
@@ -435,7 +435,7 @@ v2.putWallet = {
   },
 
   description: 'Sets information for a verified publisher',
-  tags: [ 'api' ],
+  tags: [ 'api', 'publishers' ],
 
   validate: {
     headers: Joi.object({ authorization: Joi.string().required() }).unknown(),
@@ -481,7 +481,7 @@ v1.identity =
 },
 
   description: 'Returns the publisher identity associated with a URL',
-  tags: [ 'api' ],
+  tags: [ 'api', 'publishers' ],
 
   validate: {
     headers: Joi.object({ authorization: Joi.string().required() }).unknown(),
@@ -631,7 +631,7 @@ v1.getStatement = {
   },
 
   description: 'Generates a statement for a publisher',
-  tags: [ 'api' ],
+  tags: [ 'api', 'publishers' ],
 
   validate: {
     headers: Joi.object({ authorization: Joi.string().required() }).unknown(),
@@ -668,7 +668,7 @@ v1.putToken = {
   },
 
   description: 'Gets a verification token for a publisher',
-  tags: [ 'api', 'deprecated' ],
+  tags: [ 'api', 'publishers', 'deprecated' ],
 
   validate: {
     headers: Joi.object({ authorization: Joi.string().required() }).unknown(),
@@ -816,7 +816,7 @@ v1.getToken = {
   },
 
   description: 'Verifies a publisher',
-  tags: [ 'api', 'deprecated' ],
+  tags: [ 'api', 'publishers', 'deprecated' ],
 
   validate: {
     params: { publisher: braveJoi.string().publisher().required().description('the publisher identity') },

--- a/eyeshade/controllers/publishers.js
+++ b/eyeshade/controllers/publishers.js
@@ -9,6 +9,7 @@ const Joi = require('joi')
 const underscore = require('underscore')
 const uuid = require('uuid')
 
+const batPublisher = require('bat-publisher')
 const utils = require('bat-utils')
 const braveHapi = utils.extras.hapi
 const braveJoi = utils.extras.joi
@@ -65,7 +66,7 @@ v1.bulk = {
   },
 
   description: 'Creates publisher entries in bulk',
-  tags: [ 'api' ],
+  tags: [ 'api', 'deprecated' ],
 
   validate: {
     query: { format: Joi.string().valid('json', 'csv').optional().default('json').description('the format of the report') },
@@ -456,6 +457,118 @@ v2.putWallet = {
 }
 
 /*
+   GET /v1/publishers/identity?url=...
+       [ used by publishers ]
+ */
+
+v1.identity =
+{ handler: (runtime) => {
+  return async (request, reply) => {
+    const url = request.query.url
+    const debug = braveHapi.debug(module, request)
+    let result
+
+    try {
+      result = batPublisher.getPublisherProps(url)
+      if (!result) return reply(boom.notFound())
+
+      if (!result.publisherType) {
+        result.publisher = batPublisher.getPublisher(url, ruleset)
+        if (result.publisher) underscore.extend(result, await identity(debug, runtime, result))
+      }
+
+      reply(result)
+    } catch (ex) {
+      reply(boom.badData(ex.toString()))
+    }
+  }
+},
+
+  description: 'Returns the publisher identity associated with a URL',
+  tags: [ 'api' ],
+
+  validate: {
+    query: {
+      url: Joi.string().uri({ scheme: /https?/ }).required().description('the URL to parse'),
+      access_token: Joi.string().guid().optional()
+    }
+  },
+
+  response:
+    { schema: Joi.object().optional().description('the publisher identity') }
+}
+
+const ruleset = [
+  {
+    'condition': "SLD === 'youtube.com' && pathname.indexOf('/channel/') === 0",
+    'consequent': "'youtube#channel:' + pathname.split('/')[2]",
+    'description': 'youtube channels'
+  },
+  {
+    'condition': '/^[a-z][a-z].gov$/.test(SLD)',
+    'consequent': 'QLD + "." + SLD',
+    'description': 'governmental sites'
+  },
+  {
+    'condition': "TLD === 'gov' || /^go.[a-z][a-z]$/.test(TLD) || /^gov.[a-z][a-z]$/.test(TLD)",
+    'consequent': 'SLD',
+    'description': 'governmental sites'
+  },
+  {
+    'condition': "SLD === 'keybase.pub'",
+    'consequent': "QLD + '.' + SLD",
+    'description': 'keybase users'
+  },
+  {
+    'condition': "SLD === 'youtube.com' && pathname.indexOf('/channel/') === 0",
+    'consequent': "'youtube#channel:' + pathname.split('/')[2]",
+    'description': 'youtube channels'
+  },
+  {
+    'condition': true,
+    'consequent': 'SLD',
+    'description': 'the default rule'
+  }
+]
+
+const identity = async (debug, runtime, result) => {
+  const publishersV2 = runtime.database.get('publishersV2', debug)
+  let entry
+
+  const re = (value, entries) => {
+    entries.forEach((reEntry) => {
+      let regexp
+
+      if ((entry) ||
+          (underscore.intersection(reEntry.publisher.split(''),
+                                [ '^', '$', '*', '+', '?', '[', '(', '{', '|' ]).length === 0)) return
+
+      try {
+        regexp = new RegExp(reEntry.publisher)
+        if (regexp.test(value)) entry = reEntry
+      } catch (ex) {
+        debug('invalid regexp ' + reEntry.publisher + ': ' + ex.toString())
+      }
+    })
+  }
+
+  entry = await publishersV2.findOne({ publisher: result.publisher, facet: 'domain' })
+
+  if (!entry) entry = await publishersV2.findOne({ publisher: result.SLD.split('.')[0], facet: 'SLD' })
+  if (!entry) re(result.SLD, await publishersV2.find({ facet: 'SLD' }))
+
+  if (!entry) entry = await publishersV2.findOne({ publisher: result.TLD, facet: 'TLD' })
+  if (!entry) re(result.TLD, await publishersV2.find({ facet: 'TLD' }))
+
+  if (!entry) return {}
+
+  return {
+    properties: underscore.omit(entry, [ '_id', 'publisher', 'timestamp' ]),
+    timestamp: entry.timestamp.toString()
+  }
+}
+
+/*
    GET /v1/publishers/statement
  */
 
@@ -549,27 +662,11 @@ v1.getStatement = {
        [ used by publishers ]
  */
 
-v1.getToken = {
+v1.putToken = {
   handler: (runtime) => {
     return async (request, reply) => {
-      const publisher = request.params.publisher
-      const verificationId = request.params.verificationId
-      const visible = request.query.show_verification_status
-      const debug = braveHapi.debug(module, request)
-      const tokens = runtime.database.get('tokens', debug)
-      let entry, state, token
-
-      entry = await tokens.findOne({ verificationId: verificationId, publisher: publisher })
-      if (entry) return reply({ token: entry.token })
-
-      token = crypto.randomBytes(32).toString('hex')
-      state = {
-        $currentDate: { timestamp: { $type: 'timestamp' } },
-        $set: { token: token, visible: visible }
-      }
-      await tokens.update({ verificationId: verificationId, publisher: publisher }, state, { upsert: true })
-
-      reply({ token: token })
+      putToken(request, reply, runtime, null, request.params.publisher, request.params.verificationId,
+               request.query.show_verification_status)
     }
   },
 
@@ -579,7 +676,7 @@ v1.getToken = {
   },
 
   description: 'Gets a verification token for a publisher',
-  tags: [ 'api' ],
+  tags: [ 'api', 'deprecated' ],
 
   validate: {
     params: {
@@ -594,6 +691,25 @@ v1.getToken = {
 
   response:
     { schema: Joi.object().keys({ token: Joi.string().hex().length(64).required().description('verification token') }) }
+}
+
+const putToken = async (request, reply, runtime, owner, publisher, verificationId, visible) => {
+  const debug = braveHapi.debug(module, request)
+  const tokens = runtime.database.get('tokens', debug)
+  let entry, state, token
+
+  entry = await tokens.findOne({ verificationId: verificationId, publisher: publisher })
+  if (entry) return reply({ token: entry.token })
+
+  token = crypto.randomBytes(32).toString('hex')
+  state = {
+    $currentDate: { timestamp: { $type: 'timestamp' } },
+    $set: { token: token, visible: visible }
+  }
+  if (owner) state.$set.owner = owner
+  await tokens.update({ verificationId: verificationId, publisher: publisher }, state, { upsert: true })
+
+  reply({ token: token })
 }
 
 /*
@@ -692,6 +808,114 @@ v1.deletePublisher = {
        [ used by publishers ]
  */
 
+v1.getToken = {
+  handler: (runtime) => {
+    return async (request, reply) => {
+      getToken(request, reply, runtime, null, request.params.publisher, request.query.backgroundP)
+    }
+  },
+
+  description: 'Verifies a publisher',
+  tags: [ 'api', 'deprecated' ],
+
+  validate: {
+    params: { publisher: braveJoi.string().publisher().required().description('the publisher identity') },
+    query: { backgroundP: Joi.boolean().optional().default(false).description('running in the background') }
+  },
+
+  response: {
+    schema: Joi.object().keys({
+      status: Joi.string().valid('success', 'failure').required().description('victory is mine!'),
+      verificationId: Joi.string().guid().optional().description('identity of the verified requestor')
+    })
+  }
+}
+
+const getToken = async (request, reply, runtime, owner, publisher, backgroundP) => {
+  const debug = braveHapi.debug(module, request)
+  const tokens = runtime.database.get('tokens', debug)
+  let data, entries, hint, i, info, j, matchP, pattern, reason, rr, rrset
+
+  entries = await tokens.find({ publisher: publisher })
+  if (entries.length === 0) return reply(boom.notFound('no such publisher: ' + publisher))
+
+  for (let entry of entries) {
+    if (entry.verified) {
+      await runtime.queue.send(debug, 'publisher-report',
+                               underscore.pick(entry, [ 'owner', 'publisher', 'verified', 'visible' ]))
+      return reply({ status: 'success', verificationId: entry.verificationId })
+    }
+  }
+
+  try { rrset = await dnsTxtResolver(publisher) } catch (ex) {
+    reason = ex.toString()
+    if (reason.indexOf('ENODATA') === -1) {
+      debug('dnsTxtResolver', underscore.extend({ publisher: publisher, reason: reason }))
+    }
+    rrset = []
+  }
+  for (i = 0; i < rrset.length; i++) { rrset[i] = rrset[i].join('') }
+
+  const loser = async (entry, reason) => {
+    debug('verify', underscore.extend(info, { reason: reason }))
+    await verified(request, reply, runtime, entry, false, backgroundP, reason)
+  }
+
+  info = { publisher: publisher }
+  data = {}
+  for (let entry of entries) {
+    info.verificationId = entry.verificationId
+
+    for (j = 0; j < rrset.length; j++) {
+      rr = rrset[j]
+      if (rr.indexOf(prefix2) !== 0) continue
+
+      matchP = true
+      if (rr.substring(prefix2.length) !== entry.token) {
+        await loser(entry, 'TXT RR suffix mismatch ' + prefix2 + entry.token)
+        continue
+      }
+
+      return verified(request, reply, runtime, entry, true, backgroundP, 'TXT RR matches')
+    }
+    if (!matchP) {
+      if (typeof matchP === 'undefined') await loser(entry, 'no TXT RRs starting with ' + prefix2)
+      matchP = false
+    }
+
+    for (j = 0; j < hintsK.length; j++) {
+      hint = hintsK[j]
+      if (typeof data[hint] === 'undefined') {
+        try { data[hint] = (await webResolver(debug, runtime, publisher, hints[hint])).toString() } catch (ex) {
+          data[hint] = ''
+          await loser(entry, ex.toString())
+          continue
+        }
+        debug('verify', 'fetched data for ' + hint)
+      }
+
+      if (data[hint].indexOf(entry.token) !== -1) {
+        switch (hint) {
+          case root:
+            pattern = '<meta[^>]*?name=["\']+' + prefix1 + '["\']+content=["\']+' + entry.token + '["\']+.*?>|' +
+                    '<meta[^>]*?content=["\']+' + entry.token + '["\']+name=["\']+' + prefix1 + '["\']+.*?>'
+            if (!data[hint].match(pattern)) continue
+            break
+
+          default:
+            break
+        }
+        return verified(request, reply, runtime, entry, true, backgroundP, hint + ' web file matches')
+      }
+      debug('verify', 'no match for ' + hint)
+
+      if (i === 0) break
+    }
+  }
+
+  reply({ status: 'failure' })
+}
+
 const hints = {
   standard: '/.well-known/brave-payments-verification.txt',
   root: '/'
@@ -702,6 +926,7 @@ const dnsTxtResolver = async (domain) => {
   return new Promise((resolve, reject) => {
     dns.resolveTxt(domain, (err, rrset) => {
       if (err) return reject(err)
+
       resolve(rrset)
     })
   })
@@ -731,9 +956,10 @@ const webResolver = async (debug, runtime, publisher, path) => {
 const verified = async (request, reply, runtime, entry, verified, backgroundP, reason) => {
   const indices = underscore.pick(entry, [ 'verificationId', 'publisher' ])
   const debug = braveHapi.debug(module, request)
+  const owners = runtime.database.get('owners', debug)
   const publishers = runtime.database.get('publishers', debug)
   const tokens = runtime.database.get('tokens', debug)
-  let info, message, method, payload, results, state, visible, visibleP
+  let info, message, method, payload, props, results, state, visible, visibleP
 
   message = underscore.extend(underscore.clone(indices), { verified: verified, reason: reason })
   debug('verified', message)
@@ -761,13 +987,23 @@ const verified = async (request, reply, runtime, entry, verified, backgroundP, r
 
   state = {
     $currentDate: { timestamp: { $type: 'timestamp' } },
-    $set: underscore.pick(entry, [ 'verified', 'visible', 'info' ])
+    $set: underscore.pick(entry, [ 'owner', 'verified', 'visible', 'info' ])
   }
   await publishers.update({ publisher: entry.publisher }, state, { upsert: true })
 
   await tokens.remove({ publisher: entry.publisher, verified: false })
 
-  await runtime.queue.send(debug, 'publisher-report', underscore.pick(entry, [ 'publisher', 'verified', 'visible' ]))
+  if (entry.owner) {
+    props = batPublisher.getPublisherProps(entry.owner)
+
+    state = {
+      $currentDate: { timestamp: { $type: 'timestamp' } },
+      $set: underscore.pick(props || {}, [ 'providerName', 'providerSuffix', 'providerValue' ])
+    }
+    await owners.update({ owner: entry.owner }, state, { upsert: true })
+  }
+
+  await runtime.queue.send(debug, 'publisher-report', underscore.pick(entry, [ 'owner', 'publisher', 'verified', 'visible' ]))
   reply({ status: 'success', verificationId: entry.verificationId })
 
   if (entry.info) return
@@ -792,111 +1028,6 @@ const verified = async (request, reply, runtime, entry, verified, backgroundP, r
     await tokens.update(indices, state, { upsert: true })
 
     await publishers.update(indices, state, { upsert: true })
-  }
-}
-
-v1.verifyToken = {
-  handler: (runtime) => {
-    return async (request, reply) => {
-      const publisher = request.params.publisher
-      const backgroundP = request.query.backgroundP
-      const debug = braveHapi.debug(module, request)
-      const tokens = runtime.database.get('tokens', debug)
-      let data, entries, hint, i, info, j, matchP, pattern, reason, rr, rrset
-
-      entries = await tokens.find({ publisher: publisher })
-      if (entries.length === 0) return reply(boom.notFound('no such publisher: ' + publisher))
-
-      for (let entry of entries) {
-        if (entry.verified) {
-          await runtime.queue.send(debug, 'publisher-report', underscore.pick(entry, [ 'publisher', 'verified', 'visible' ]))
-          return reply({ status: 'success', verificationId: entry.verificationId })
-        }
-      }
-
-      try { rrset = await dnsTxtResolver(publisher) } catch (ex) {
-        reason = ex.toString()
-        if (reason.indexOf('ENODATA') === -1) {
-          debug('dnsTxtResolver', underscore.extend({ publisher: publisher, reason: reason }))
-        }
-        rrset = []
-      }
-      for (i = 0; i < rrset.length; i++) { rrset[i] = rrset[i].join('') }
-
-      const loser = async (entry, reason) => {
-        debug('verify', underscore.extend(info, { reason: reason }))
-        await verified(request, reply, runtime, entry, false, backgroundP, reason)
-      }
-
-      info = { publisher: publisher }
-      data = {}
-      for (let entry of entries) {
-        info.verificationId = entry.verificationId
-
-        for (j = 0; j < rrset.length; j++) {
-          rr = rrset[j]
-          if (rr.indexOf(prefix2) !== 0) continue
-
-          matchP = true
-          if (rr.substring(prefix2.length) !== entry.token) {
-            await loser(entry, 'TXT RR suffix mismatch ' + prefix2 + entry.token)
-            continue
-          }
-
-          return verified(request, reply, runtime, entry, true, backgroundP, 'TXT RR matches')
-        }
-        if (!matchP) {
-          if (typeof matchP === 'undefined') await loser(entry, 'no TXT RRs starting with ' + prefix2)
-          matchP = false
-        }
-
-        for (j = 0; j < hintsK.length; j++) {
-          hint = hintsK[j]
-          if (typeof data[hint] === 'undefined') {
-            try { data[hint] = (await webResolver(debug, runtime, publisher, hints[hint])).toString() } catch (ex) {
-              data[hint] = ''
-              await loser(entry, ex.toString())
-              continue
-            }
-            debug('verify', 'fetched data for ' + hint)
-          }
-
-          if (data[hint].indexOf(entry.token) !== -1) {
-            switch (hint) {
-              case root:
-                pattern = '<meta[^>]*?name=["\']+' + prefix1 + '["\']+content=["\']+' + entry.token + '["\']+.*?>|' +
-                        '<meta[^>]*?content=["\']+' + entry.token + '["\']+name=["\']+' + prefix1 + '["\']+.*?>'
-                if (!data[hint].match(pattern)) continue
-                break
-
-              default:
-                break
-            }
-            return verified(request, reply, runtime, entry, true, backgroundP, hint + ' web file matches')
-          }
-          debug('verify', 'no match for ' + hint)
-
-          if (i === 0) break
-        }
-      }
-
-      return reply({ status: 'failure' })
-    }
-  },
-
-  description: 'Verifies a publisher',
-  tags: [ 'api' ],
-
-  validate: {
-    params: { publisher: braveJoi.string().publisher().required().description('the publisher identity') },
-    query: { backgroundP: Joi.boolean().optional().default(false).description('running in the background') }
-  },
-
-  response: {
-    schema: Joi.object().keys({
-      status: Joi.string().valid('success', 'failure').required().description('victory is mine!'),
-      verificationId: Joi.string().guid().optional().description('identity of the verified requestor')
-    })
   }
 }
 
@@ -933,18 +1064,22 @@ const notify = async (debug, runtime, publisher, payload) => {
   runtime.notify(debug, { channel: '#publishers-bot', text: 'publishers notified: ' + JSON.stringify(message) })
 }
 
+module.exports.getToken = getToken
+module.exports.putToken = putToken
+
 module.exports.routes = [
   braveHapi.routes.async().post().path('/v1/publishers').config(v1.bulk),
   braveHapi.routes.async().post().path('/v2/publishers/settlement').config(v2.settlement),
   braveHapi.routes.async().path('/v2/publishers/{publisher}/balance').whitelist().config(v2.getBalance),
   braveHapi.routes.async().path('/v2/publishers/{publisher}/wallet').whitelist().config(v2.getWallet),
   braveHapi.routes.async().put().path('/v2/publishers/{publisher}/wallet').whitelist().config(v2.putWallet),
+  braveHapi.routes.async().path('/v1/publishers/identity').whitelist().config(v1.identity),
   braveHapi.routes.async().path('/v1/publishers/statement').whitelist().config(v1.getStatements),
   braveHapi.routes.async().path('/v1/publishers/{publisher}/statement').whitelist().config(v1.getStatement),
-  braveHapi.routes.async().path('/v1/publishers/{publisher}/verifications/{verificationId}').whitelist().config(v1.getToken),
+  braveHapi.routes.async().path('/v1/publishers/{publisher}/verifications/{verificationId}').whitelist().config(v1.putToken),
   braveHapi.routes.async().patch().path('/v2/publishers/{publisher}').whitelist().config(v2.patchPublisher),
   braveHapi.routes.async().delete().path('/v1/publishers/{publisher}').whitelist().config(v1.deletePublisher),
-  braveHapi.routes.async().path('/v1/publishers/{publisher}/verify').config(v1.verifyToken)
+  braveHapi.routes.async().path('/v1/publishers/{publisher}/verify').config(v1.getToken)
 ]
 
 module.exports.initialize = async (debug, runtime) => {
@@ -1021,16 +1156,28 @@ module.exports.initialize = async (debug, runtime) => {
         authority: '',
 
      // v2 and later
+        owner: '',
+        ownerEmail: '',
+        ownerName: '',
         visible: false,
         info: {},
         method: '',
 
         reason: '',
-        timestamp: bson.Timestamp.ZERO },
+        timestamp: bson.Timestamp.ZERO
+      },
       unique: [ { verificationId: 1, publisher: 1 } ],
       others: [ { token: 1 }, { verified: 1 }, { authority: 1 },
-                { visible: 1, method: 1 },
+                { owner: 1 }, { visible: 1 }, { method: 1 },
                 { reason: 1 }, { timestamp: 1 } ]
+    },
+    {
+      category: runtime.database.get('publishersV2', debug),
+      name: 'publishersV2',
+      property: 'publisher',
+      empty: { publisher: '', facet: '', exclude: false, tags: [], timestamp: bson.Timestamp.ZERO },
+      unique: [ { publisher: 1 } ],
+      others: [ { facet: 1 }, { exclude: 1 }, { timestamp: 1 } ]
     }
   ])
 

--- a/eyeshade/controllers/publishers.js
+++ b/eyeshade/controllers/publishers.js
@@ -220,11 +220,9 @@ v2.getBalance = {
   tags: [ 'api' ],
 
   validate: {
+    headers: Joi.object({ authorization: Joi.string().required() }).unknown(),
     params: { publisher: braveJoi.string().publisher().required().description('the publisher identity') },
-    query: {
-      currency: braveJoi.string().currencyCode().optional().default('USD').description('the fiat currency'),
-      access_token: Joi.string().guid().optional()
-    }
+    query: { currency: braveJoi.string().currencyCode().optional().default('USD').description('the fiat currency') }
   },
 
   response: {
@@ -356,11 +354,9 @@ v2.getWallet = {
   tags: [ 'api' ],
 
   validate: {
+    headers: Joi.object({ authorization: Joi.string().required() }).unknown(),
     params: { publisher: braveJoi.string().publisher().required().description('the publisher identity') },
-    query: {
-      currency: braveJoi.string().currencyCode().optional().default('USD').description('the fiat currency'),
-      access_token: Joi.string().guid().optional()
-    }
+    query: { currency: braveJoi.string().currencyCode().optional().default('USD').description('the fiat currency') }
   },
 
   response: {
@@ -442,8 +438,8 @@ v2.putWallet = {
   tags: [ 'api' ],
 
   validate: {
+    headers: Joi.object({ authorization: Joi.string().required() }).unknown(),
     params: { publisher: braveJoi.string().publisher().required().description('the publisher identity') },
-    query: { access_token: Joi.string().guid().optional() },
     payload: {
       verificationId: Joi.string().guid().required().description('identity of the requestor'),
       provider: Joi.string().required().description('wallet provider'),
@@ -488,10 +484,8 @@ v1.identity =
   tags: [ 'api' ],
 
   validate: {
-    query: {
-      url: Joi.string().uri({ scheme: /https?/ }).required().description('the URL to parse'),
-      access_token: Joi.string().guid().optional()
-    }
+    headers: Joi.object({ authorization: Joi.string().required() }).unknown(),
+    query: { url: Joi.string().uri({ scheme: /https?/ }).required().description('the URL to parse') }
   },
 
   response:
@@ -595,9 +589,7 @@ v1.getStatements = {
   tags: [ 'api' ],
 
   validate: {
-    query: {
-      access_token: Joi.string().guid().optional()
-    }
+    headers: Joi.object({ authorization: Joi.string().required() }).unknown()
   },
 
   response: {
@@ -642,11 +634,11 @@ v1.getStatement = {
   tags: [ 'api' ],
 
   validate: {
+    headers: Joi.object({ authorization: Joi.string().required() }).unknown(),
     params: { publisher: braveJoi.string().publisher().required().description('the publisher identity') },
     query: {
       starting: Joi.date().iso().optional().description('starting timestamp in ISO 8601 format'),
-      ending: Joi.date().iso().optional().description('ending timestamp in ISO 8601 format'),
-      access_token: Joi.string().guid().optional()
+      ending: Joi.date().iso().optional().description('ending timestamp in ISO 8601 format')
     }
   },
 
@@ -679,12 +671,12 @@ v1.putToken = {
   tags: [ 'api', 'deprecated' ],
 
   validate: {
+    headers: Joi.object({ authorization: Joi.string().required() }).unknown(),
     params: {
       publisher: braveJoi.string().publisher().required().description('the publisher identity'),
       verificationId: Joi.string().guid().required().description('identity of the requestor')
     },
     query: {
-      access_token: Joi.string().guid().optional(),
       show_verification_status: Joi.boolean().optional().default(true).description('authorizes display')
     }
   },

--- a/eyeshade/controllers/publishers.js
+++ b/eyeshade/controllers/publishers.js
@@ -1091,7 +1091,7 @@ module.exports.initialize = async (debug, runtime) => {
       name: 'publishers',
       property: 'publisher',
       empty: {
-        publisher: '',
+        publisher: '',    // domain OR 'oauth#' + provider + ':' + (profile.id || profile._id)
         verified: false,
         authorized: false,
         authority: '',
@@ -1102,17 +1102,28 @@ module.exports.initialize = async (debug, runtime) => {
 
      // v2 and later
         owner: '',
+
+        providerName: '',
+        providerSuffix: '',
+        providerValue: '',
+        authorizerEmail: '',
+        authorizerName: '',
+
         visible: false,
+
         provider: '',
         altcurrency: '',
         parameters: {},
+
         info: {},
 
         timestamp: bson.Timestamp.ZERO
       },
       unique: [ { publisher: 1 } ],
       others: [ { verified: 1 }, { authorized: 1 }, { authority: 1 },
-                { owner: 1 }, { visible: 1 }, { provider: 1 }, { altcurrency: 1 },
+                { owner: 1 },
+                { providerName: 1 }, { providerSuffix: 1 }, { providerValue: 1 }, { authorizerEmail: 1 }, { authorizerName: 1 },
+                { visible: 1 }, { provider: 1 }, { altcurrency: 1 },
                 { timestamp: 1 } ]
     },
     {

--- a/eyeshade/controllers/reports.js
+++ b/eyeshade/controllers/reports.js
@@ -414,11 +414,11 @@ v2.publishers.status = {
   tags: [ 'api' ],
 
   validate: {
+    headers: Joi.object({ authorization: Joi.string().required() }).unknown(),
     query: {
       format: Joi.string().valid('json', 'csv').optional().default('csv').description('the format of the response'),
       summary: Joi.boolean().optional().default(true).description('summarize report'),
-      verified: Joi.boolean().optional().description('filter on verification status'),
-      access_token: Joi.string().guid().optional()
+      verified: Joi.boolean().optional().description('filter on verification status')
     }
   },
 

--- a/eyeshade/workers/publishers.js
+++ b/eyeshade/workers/publishers.js
@@ -51,7 +51,7 @@ exports.workers = {
       for (let entry of publishers) {
         visible = entry.show_verification_status
         try {
-          result = await publish(debug, runtime, 'post', '', '', {
+          result = await publish(debug, runtime, 'post', '', '', '', {
             publisher: underscore.extend({ brave_publisher_id: entry.publisher, verified: true },
                                          underscore.omit(entry, [ 'publisher' ]))
           })

--- a/eyeshade/workers/reports.js
+++ b/eyeshade/workers/reports.js
@@ -290,7 +290,7 @@ const quanta = async (debug, runtime, qid) => {
   }))
 }
 
-const mixer = async (debug, runtime, publisher, qid) => {
+const mixer = async (debug, runtime, filter, qid) => {
   const publishers = {}
   let results
 
@@ -309,7 +309,7 @@ const mixer = async (debug, runtime, publisher, qid) => {
     for (let slice of slices) {
       probi = new BigNumber(quantum.quantum.toString()).times(slice.counts).times(0.95)
       fees = new BigNumber(quantum.quantum.toString()).times(slice.counts).minus(probi)
-      if ((publisher) && (slice.publisher !== publisher)) continue
+      if ((filter) && (filter.indexOf(slice.publisher) === -1)) continue
 
       if (!publishers[slice.publisher]) {
         publishers[slice.publisher] = {
@@ -624,7 +624,7 @@ exports.workers = {
       const scale = new BigNumber(runtime.currency.alt2scale(altcurrency) || 1)
       let data, entries, file, info, previous, publishers, usd
 
-      publishers = await mixer(debug, runtime, publisher, undefined)
+      publishers = await mixer(debug, runtime, [ publisher ], undefined)
 
       underscore.keys(publishers).forEach((publisher) => {
         publishers[publisher].authorized = false
@@ -831,22 +831,34 @@ exports.workers = {
       const starting = payload.starting
       const summaryP = payload.summary
       const publisher = payload.publisher
+      const publishersC = runtime.database.get('publishers', debug)
       const settlements = runtime.database.get('settlements', debug)
       const scale = new BigNumber(runtime.currency.alt2scale(altcurrency) || 1)
-      let data, data1, data2, file, entries, publishers, query, usd
+      let data, data1, data2, file, filter, entries, publishers, query, usd
       let ending = payload.ending
 
-      if (publisher) {
-        query = { publisher: publisher }
+      if (publisher || owner) {
+        if (owner) {
+          filter = []
+          query = { $or: [ { owner: owner } ] }
+          entries = await publishersC.find({ owner: owner })
+          entries.forEach((entry) => {
+            filter.push(entry.publisher)
+            query.$or.push({ publisher: entry.publisher })
+          })
+        } else {
+          filter = [ publisher ]
+          query = { publisher: publisher }
+        }
         if ((starting) || (ending)) {
           query._id = {}
           if (starting) query._id.$gte = date2objectId(starting, false)
           if (ending) query._id.$lte = date2objectId(ending, true)
         }
         entries = await settlements.find(query)
-        publishers = await mixer(debug, runtime, publisher, query._id)
+        publishers = await mixer(debug, runtime, filter, query._id)
       } else {
-        entries = await settlements.find(owner ? { owner: owner } : hash ? { hash: hash } : {})
+        entries = await settlements.find(hash ? { hash: hash } : {})
         if ((rollupP) && (entries.length > 0)) {
           query = { $or: [] }
           entries.forEach((entry) => { query.$or.push({ publisher: entry.publisher }) })

--- a/helper/controllers/rates.js
+++ b/helper/controllers/rates.js
@@ -23,7 +23,7 @@ v1.read = { handler: (runtime) => {
   description: 'Report currency rates',
   tags: [ 'api' ],
 
-  validate: { query: { access_token: Joi.string().guid().optional() } },
+  validate: { headers: Joi.object({ authorization: Joi.string().required() }).unknown() },
 
   response: { schema: Joi.any().description('all the rates') }
 }

--- a/ledger/controllers/publisher.js
+++ b/ledger/controllers/publisher.js
@@ -87,7 +87,7 @@ v1.read =
     const consequential = request.query.consequential
     const entry = consequential ? (await rulesetEntryV2(request, runtime)) : (await rulesetEntry(request, runtime))
 
-    return reply(entry.ruleset)
+    reply(entry.ruleset)
   }
 },
 
@@ -436,7 +436,7 @@ v2.identity =
 },
 
   description: 'Returns the publisher identity associated with a URL',
-  tags: [ 'api' ],
+  tags: [ 'api', 'deprecated' ],
 
   validate:
     { query: { url: Joi.string().uri({ scheme: /https?/ }).required().description('the URL to parse') } },
@@ -603,27 +603,27 @@ v2.verified =
 }
 
 module.exports.routes = [
-  braveHapi.routes.async().get().path('/v1/publisher/ruleset').config(v1.read),
-  braveHapi.routes.async().get().path('/v1/publisher/ruleset/version').config(v1.version),
+  braveHapi.routes.async().path('/v1/publisher/ruleset').config(v1.read),
+  braveHapi.routes.async().path('/v1/publisher/ruleset/version').config(v1.version),
 /*
-  braveHapi.routes.async().get().path('/v1/publisher/identity').config(v1.identity),
+  braveHapi.routes.async().path('/v1/publisher/identity').config(v1.identity),
 */
 
-  braveHapi.routes.async().get().path('/v2/publisher/ruleset').config(v2.read),
+  braveHapi.routes.async().path('/v2/publisher/ruleset').config(v2.read),
   braveHapi.routes.async().post().path('/v2/publisher/ruleset').config(v2.create),
   braveHapi.routes.async().patch().path('/v2/publisher/rulesets').config(v2.update),
   braveHapi.routes.async().put().path('/v2/publisher/ruleset/{publisher}').config(v2.write),
   braveHapi.routes.async().delete().path('/v2/publisher/ruleset/{publisher}').config(v2.delete),
-  braveHapi.routes.async().get().path('/v2/publisher/identity').config(v2.identity),
+  braveHapi.routes.async().path('/v2/publisher/identity').config(v2.identity),
 
-  braveHapi.routes.async().get().path('/v3/publisher/identity').config(v3.identity),
-  braveHapi.routes.async().get().path('/v3/publisher/timestamp').config(v3.timestamp),
+  braveHapi.routes.async().path('/v3/publisher/identity').config(v3.identity),
+  braveHapi.routes.async().path('/v3/publisher/timestamp').config(v3.timestamp),
 
 /*
-  braveHapi.routes.async().get().path('/v1/publisher/identity/verified').config(v1.verified),
+  braveHapi.routes.async().path('/v1/publisher/identity/verified').config(v1.verified),
 */
 
-  braveHapi.routes.async().get().path('/v2/publisher/identity/verified').config(v2.verified)
+  braveHapi.routes.async().path('/v2/publisher/identity/verified').config(v2.verified)
 ]
 
 module.exports.initialize = async (debug, runtime) => {

--- a/ledger/workers/publisher.js
+++ b/ledger/workers/publisher.js
@@ -12,7 +12,8 @@ exports.workers = {
 
     { queue            : 'publisher-report'
     , message          :
-      { publisher      : '...'
+      { owner          : '...'
+      , publisher      : '...'
       , verified       : true | false
       , visible        : true | false
       }


### PR DESCRIPTION
- add `POST /v2/owners` for both websites and oauth publishers
- add `GET /v1/owners/{owner}/verify/{publisher}` and `PUT /v1/owners/{owner}/verify/{publisher}` for website publisher verification
- deprecate `POST /v1/publishers`
- add `GET /v1/publishers/identity?url=…` to eyeshade to replace `GET/v2/publishers/identity?url=…` on ledger
- put oauth name/email into corresponding publisher entries
- handle per-owner reports