### PR TITLE
If probi < 0, then set probi to BigNumber(0)

### DIFF
--- a/eyeshade/controllers/publishers.js
+++ b/eyeshade/controllers/publishers.js
@@ -293,7 +293,7 @@ v2.getWallet = {
       if (summary.length > 0) probi = probi.minus(new BigNumber(summary[0].probi.toString()))
       if (probi.lessThan(0)) {
         runtime.captureException(new Error('negative probi'), { extra: { publisher: publisher, probi: probi.toString() } })
-        probi = 0
+        probi = new BigNumber(0)
       }
 
       amount = runtime.currency.alt2fiat(altcurrency, probi, currency) || 0


### PR DESCRIPTION
To avoid throwing on `probi.truncated().toString()`

No transcript for this, but inspired by https://sentry.io/brave-software/eyeshade-production/issues/427843325/