### PR TITLE
Re-enable green check-marks

### DIFF
--- a/ledger/controllers/publisher.js
+++ b/ledger/controllers/publisher.js
@@ -640,6 +640,13 @@ module.exports.initialize = async (debug, runtime) => {
       unique: [ { rulesetId: 1 } ],
       others: [ { type: 1 }, { version: 1 }, { timestamp: 1 } ]
     },
+/* verified publishers
+   - verified should always be "true"
+   - visible indicates whether the publisher opted-in to inclusion in marketing materials
+
+   originally this was the 'publishers' table, but was renamed to 'publishersX' to temporarily address a publisher privacy
+   issue. however, it was accidentally commented out, which resulted in vanilla servers not getting the indices...
+ */
     {
       category: runtime.database.get('publishersX', debug),
       name: 'publishersX',

--- a/ledger/controllers/publisher.js
+++ b/ledger/controllers/publisher.js
@@ -480,7 +480,7 @@ v3.identity =
         if ((timestamp) && ((!result.properties.timestamp) || (timestamp > result.properties.timestamp))) {
           result.properties.timestamp = timestamp
         }
-        if (entry.visible) result.properties.verified = entry.verified
+        if (entry.verified) result.properties.verified = entry.verified
       }
 
       reply(result)
@@ -640,16 +640,14 @@ module.exports.initialize = async (debug, runtime) => {
       unique: [ { rulesetId: 1 } ],
       others: [ { type: 1 }, { version: 1 }, { timestamp: 1 } ]
     },
-/* deprecated
     {
       category: runtime.database.get('publishers', debug),
-      name: 'publishers',
+      name: 'publishersX',
       property: 'publisher',
       empty: { publisher: '', tld: '', verified: false, visible: false, timestamp: bson.Timestamp.ZERO },
       unique: [ { publisher: 1 } ],
       others: [ { tld: 1 }, { verified: 1 }, { visible: 1 }, { timestamp: 1 } ]
     },
- */
     {
       category: publishers,
       name: 'publishersV2',

--- a/ledger/controllers/publisher.js
+++ b/ledger/controllers/publisher.js
@@ -641,7 +641,7 @@ module.exports.initialize = async (debug, runtime) => {
       others: [ { type: 1 }, { version: 1 }, { timestamp: 1 } ]
     },
     {
-      category: runtime.database.get('publishers', debug),
+      category: runtime.database.get('publishersX', debug),
       name: 'publishersX',
       property: 'publisher',
       empty: { publisher: '', tld: '', verified: false, visible: false, timestamp: bson.Timestamp.ZERO },


### PR DESCRIPTION
Complete the separation of `verified` (green check-mark) and `visible` (opted-in to marketing use).

Current:

    % curl -s -X GET --header 'Accept: application/json' 'https://ledger.mercury.basicattentiontoken.org/v3/publisher/identity?publisher=nickvonpentz.com' | json_pp
    {
    "QLD" : "",
    "properties" : {
    "timestamp" : "6493179644546646017"
    },
    "SLD" : "nickvonpentz.com",
    "publisher" : "nickvonpentz.com",
    "RLD" : ""
    }

New:

    % curl -s -X GET --header 'Accept: application/json' 'http://127.0.0.1:3001/v3/publisher/identity?publisher=nickvonpentz.com' | json_pp
    {
    "publisher" : "nickvonpentz.com",
    "SLD" : "nickvonpentz.com",
    "properties" : {
    "verified" : true,
    "timestamp" : "6501003756404998145"
    },
    "QLD" : "",
    "RLD" : ""
    }
