### PR TITLE
Now that eyeshade is re-sync'd, time to revert the detour..

### DIFF
--- a/ledger/workers/publisher.js
+++ b/ledger/workers/publisher.js
@@ -22,7 +22,7 @@ exports.workers = {
   'publisher-report':
     async (debug, runtime, payload) => {
       const publisher = payload.publisher
-      const publishers = runtime.database.get('publishersY', debug)
+      const publishers = runtime.database.get('publishersX', debug)
       const tld = tldjs.getPublicSuffix(publisher)
       let state
 


### PR DESCRIPTION
This reverts a change that was made yesterday to prevent the eyeshade mis-sync from putting out incorrect green check-marks.