### PR TITLE
Use redis to distribute prometheus stats for all dynos in a service

### DIFF
--- a/bat-utils/lib/hapi-server.js
+++ b/bat-utils/lib/hapi-server.js
@@ -57,7 +57,9 @@ const Server = async (options, runtime) => {
     })
   }
 
-  epimetheus.instrument(server)
+  if (runtime.config.prometheus) server.register(runtime.prometheus.plugin())
+  else epimetheus.instrument(server)
+
   server.register(
     [ bell,
       blipp,
@@ -107,7 +109,7 @@ const Server = async (options, runtime) => {
           methods: [ 'get', 'post', 'delete', 'put', 'patch' ],
           overLimitError: (rate) => boom.tooManyRequests(`try again in ${rate.window} seconds`),
           rateLimitKey: (request) => whitelist.ipaddr(request) + ':' + runtime.config.server.host,
-          redisClient: runtime.cache ? runtime.cache.cache : runtime.config.queue.client
+          redisClient: (runtime.cache && runtime.cache.cache) || runtime.queue.config.client
         }
       },
       {

--- a/bat-utils/lib/runtime-prometheus.js
+++ b/bat-utils/lib/runtime-prometheus.js
@@ -1,9 +1,141 @@
+// TODO: add GC statistics
+
+const SDebug = require('sdebug')
 const client = require('prom-client')
+const debug = new SDebug('prometheus')
+const epimetheus = require('epimetheus')
+const exposition = require('exposition')
+const redis = require('redis')
+const underscore = require('underscore')
 
 const Prometheus = function (config, runtime) {
   if (!(this instanceof Prometheus)) return new Prometheus(config, runtime)
 
   this.metrics = {}
+
+  if (!config.prometheus) return
+
+  this.label = config.prometheus.label
+  this.runtime = runtime
+  this.local = {}
+  this.global = {}
+
+  if (config.prometheus.redis) this.publisher = redis.createClient(config.prometheus.redis)
+  this.msgno = 0
+
+  setInterval(this.maintenance.bind(this), 10 * 1000)
+}
+
+Prometheus.prototype.plugin = function () {
+  let self = this
+
+  let plugin = {
+    register: (server, o, done) => {
+      server.route({
+        method: 'GET',
+        path: '/metrics',
+        handler: (req, reply) => {
+          reply(exposition.stringify(underscore.values(self.global))).type('text/plain')
+        }
+      })
+
+      epimetheus.instrument(server, { url: '/metrics-internal' })
+
+      return done()
+    }
+  }
+
+  plugin.register.attributes = {
+    name: 'runtime-prometheus',
+    version: '1.0.0'
+  }
+
+  return plugin
+}
+
+Prometheus.prototype.maintenance = function () {
+  let self = this
+
+  const entries = exposition.parse(client.register.metrics())
+  let updates
+
+  const merge = (source, destination) => {
+    source.forEach((update) => {
+      const name = update.name
+      let entry
+
+      if (!(update.metrics && update.metrics.length)) return
+
+      entry = destination[name]
+      if (!entry) {
+        destination[name] = update
+        return
+      }
+
+      update.metrics.forEach((metric) => {
+        const offset = underscore.findIndex(entry.metrics, (value) => {
+          return underscore.isEqual(metric.labels, value.labels)
+        })
+        if (offset < 0) entry.metrics.push(metric)
+        else entry.metrics.splice(offset, 1, metric)
+      })
+    })
+  }
+
+  updates = []
+  entries.forEach((entry) => {
+    const metrics = []
+    const name = entry.name
+
+    // no metrics(?) or no change
+    if ((!entry.metrics) || (underscore.isEqual(self.local[name] || {}, entry))) return
+
+    self.local[name] = entry
+    entry = underscore.clone(entry)
+    entry.metrics.forEach((metric) => {
+      metric.labels = underscore.clone(metric.labels) || {}
+      underscore.extend(metric.labels, { dyno: self.label })
+      metrics.push(metric)
+    })
+    entry.metrics = metrics
+
+    updates.push(entry)
+  })
+  if (!updates.length) return
+
+  merge(updates, self.global)
+
+  if (!self.publisher) {
+    self.publisher = (self.runtime.cache && self.runtime.cache.cache) || self.runtime.queue.config.client
+    if (!self.publisher) return
+  }
+
+  self.publisher.publish('prometheus', JSON.stringify({ label: self.label, msgno: self.msgno++, updates: updates }))
+  if (self.label.indexOf('.worker.') !== -1) return
+
+  if (self.subscriber) return
+
+  self.subscriber = self.publisher.duplicate().on('subscribe', (channel, count) => {
+    debug('subscribe', { channel: channel, count: count })
+  }).on('message', (channel, message) => {
+    let packet
+
+    try {
+      packet = JSON.parse(message)
+    } catch (ex) {
+      return debug('message', { error: ex.toString() })
+    }
+
+    if (packet.label === self.label) return
+
+    if (packet.msgno === 0) {
+      self.publisher.publish('prometheus', JSON.stringify({ label: self.label, msgno: self.msgno++, updates: self.global }))
+    }
+
+    merge(packet.updates, self.global)
+  })
+
+  self.subscriber.subscribe('prometheus')
 }
 
 Prometheus.prototype.setCounter = async function (name, help, value) {

--- a/bat-utils/lib/runtime-queue.js
+++ b/bat-utils/lib/runtime-queue.js
@@ -14,12 +14,12 @@ const Queue = function (config, runtime) {
 
   if (!config.queue) return
 
-  if (config.queue.rsmq) config.queue = config.queue.rsmq
-  if (typeof config.queue === 'string') {
-    if (config.queue.indexOf('redis://') === -1) config.queue = 'redis://' + config.queue
-    config.queue = { client: redis.createClient(config.queue) }
+  this.config = config.queue.rsmq || config.queue
+  if (typeof this.config === 'string') {
+    if (this.config.indexOf('redis://') === -1) this.config = 'redis://' + this.config
+    this.config = { client: redis.createClient(this.config) }
   }
-  this.rsmq = new Rsmq(config.queue)
+  this.rsmq = new Rsmq(this.config)
   this.runtime = runtime
 
   this.rsmq.on('connect', () => { debug('redis connect') })

--- a/config.js
+++ b/config.js
@@ -160,3 +160,10 @@ if (process.env.GITHUB_ORG) {
   , isSecure            : process.env.GITHUB_FORCE_HTTPS        || false
   }
 }
+
+if (process.env.DYNO) {
+  module.exports.prometheus =
+    { label              : process.env.SERVICE + '.' + process.env.DYNO
+    , redis              : process.env.REDIS2_URL               || false
+    }
+}

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "dotenv": "^4.0.0",
     "epimetheus": "1.0.55",
     "ethereum-address": "0.0.4",
+    "exposition": "^1.2.0",
     "faye-websocket": "0.11.1",
     "github": "11.0.0",
     "glob": "^7.1.2",


### PR DESCRIPTION
If $DYNO is defined and redis is available, then all dynos will publish to redis, and web dynos will report the consolidated metrics.

Fixes https://github.com/brave-intl/bat-ledger/issues/130