### PR TITLE
When doing sanity checks

### DIFF
--- a/eyeshade/workers/reports.js
+++ b/eyeshade/workers/reports.js
@@ -241,6 +241,8 @@ const sanity = async (debug, runtime) => {
 
       publisher = await publishers.findOne({ publisher: entry.publisher })
       if (!publisher) {
+        if (!entry.verified) continue
+
         debug('sanity', { message: 'remove', token: id, publisher: entry.publisher })
         await tokens.remove(id)
         continue


### PR DESCRIPTION
when looking at a verification token entry, if the publisher entry hasn’t been created, then the token entry MUST have `verified=false`

@ayumi - this should prevent future 404s from occurring; however, we need to deal with the existing 404s. the eyeshade entries with them can not be recovered, sadly... let's discuss on #publishers ... thanks!