### PR TITLE
must also delete verifications tokens when deleting a publisher

### DIFF
--- a/eyeshade/controllers/owners.js
+++ b/eyeshade/controllers/owners.js
@@ -338,6 +338,7 @@ v1.unlinkPublisher = {
       const debug = braveHapi.debug(module, request)
       const owners = runtime.database.get('owners', debug)
       const publishers = runtime.database.get('publishers', debug)
+      const tokens = runtime.database.get('tokens', debug)
       let entry, state
 
       entry = await owners.findOne({ owner: owner })

--- a/eyeshade/controllers/owners.js
+++ b/eyeshade/controllers/owners.js
@@ -352,6 +352,8 @@ v1.unlinkPublisher = {
       }
       await publishers.update({ publisher: publisher }, state, { upsert: true })
 
+      await tokens.remove({ publisher: publisher }, { justOne: false })
+
       reply({})
     }
   },


### PR DESCRIPTION
Otherwise, a new owner can not be used to verify the publisher