### PR TITLE
fix eyeshade notification

### DIFF
--- a/eyeshade/controllers/owners.js
+++ b/eyeshade/controllers/owners.js
@@ -697,7 +697,7 @@ v1.patchWallet = {
         channel: '#publishers-bot',
         text: 'owner ' + ownerString(owner, entry.info) + ' ' +
           (payload.parameters && (payload.parameters.access_token || payload.defaultCurrency) ? 'registered with'
-           : 'unregistered from') + ' ' + provider + ': ' + sites.join(' ')
+           : 'unregistered from') + ' ' + (provider || entry.provider) + ': ' + sites.join(' ')
       })
 
       reply({})


### PR DESCRIPTION
If provider not provided as a parameter to `PATCH` use the value in the
database for the notification