### PR TITLE
expose scope in GET owner wallet endpoint

### DIFF
--- a/eyeshade/controllers/owners.js
+++ b/eyeshade/controllers/owners.js
@@ -519,6 +519,9 @@ v1.getWallet = {
         if (provider && entry.parameters) result.wallet = await runtime.wallet.status(entry)
         if (result.wallet) {
           result.wallet = underscore.pick(result.wallet, [ 'provider', 'authorized', 'defaultCurrency', 'availableCurrencies', 'possibleCurrencies' ])
+          if (entry.parameters.scope) {
+            result.wallet.scope = entry.parameters.scope
+          }
           rates = result.rates
 
           underscore.union([ result.wallet.defaultCurrency ], result.wallet.availableCurrencies).forEach((currency) => {
@@ -576,7 +579,8 @@ v1.getWallet = {
         authorized: Joi.boolean().optional().description('publisher is authorized by provider'),
         defaultCurrency: braveJoi.string().anycurrencyCode().optional().default('USD').description('the default currency to pay a publisher in'),
         availableCurrencies: Joi.array().items(braveJoi.string().anycurrencyCode()).description('currencies the publisher has cards for'),
-        possibleCurrencies: Joi.array().items(braveJoi.string().anycurrencyCode()).description('currencies the publisher could have cards for')
+        possibleCurrencies: Joi.array().items(braveJoi.string().anycurrencyCode()).description('currencies the publisher could have cards for'),
+        scope: Joi.string().optional().description('scope of authorization with wallet provider')
       }).unknown(true).optional().description('publisher wallet information'),
       status: Joi.object().keys({
         provider: Joi.string().required().description('wallet provider'),

--- a/test/eyeshade/owners.integration.test.js
+++ b/test/eyeshade/owners.integration.test.js
@@ -123,9 +123,11 @@ test('eyeshade POST /v2/owners with site channels', async t => {
 })
 
 test('eyeshade PUT /v1/owners/{owner}/wallet with uphold parameters', async t => {
-  t.plan(15)
+  t.plan(16)
 
   const OWNER = 'publishers#uuid:8f3ae7ad-2842-53fd-8b63-c843afe1a33a'
+  const SCOPE = 'cards:read user:read'
+
   const dataPublisherWithSite = {
     'ownerId': OWNER,
     'contactInfo': {
@@ -151,7 +153,8 @@ test('eyeshade PUT /v1/owners/{owner}/wallet with uphold parameters', async t =>
   const dataOwnerWalletParams = {
     'provider': 'uphold',
     'parameters': {
-      'access_token': process.env.UPHOLD_ACCESS_TOKEN
+      'access_token': process.env.UPHOLD_ACCESS_TOKEN,
+      'scope': SCOPE
     }
   }
   await eyeshadeAgent.put(`/v1/owners/${encodeURIComponent(OWNER)}/wallet`)
@@ -186,6 +189,8 @@ test('eyeshade PUT /v1/owners/{owner}/wallet with uphold parameters', async t =>
   t.is(Array.isArray(wallet['possibleCurrencies']), true, 'get wallet returns currencies we could create a card for')
   t.is(wallet['possibleCurrencies'].indexOf('BAT') !== -1, true, 'wallet can have a BAT card')
   t.is(wallet['possibleCurrencies'].indexOf('JPY') !== -1, true, 'wallet can have a JPY card')
+
+  t.is(wallet['scope'], SCOPE, 'get wallet returns authorization scope')
 })
 
 test('eyeshade: create brave youtube channel and owner, verify with uphold, add BAT card', async t => {


### PR DESCRIPTION
currently publishers is not able to determine if it needs to ask for re-authorization in order to create a new wallet card - this exposes scope so it can do so