### PR TITLE
deny browser-laptop grants t2

### DIFF
--- a/ledger/controllers/grants.js
+++ b/ledger/controllers/grants.js
@@ -31,7 +31,6 @@ const joiGrantSubset = Joi.object().keys({
   probi: braveJoi.string().numeric().optional().description('the grant amount in probi')
 }).unknown(true).description('grant properties')
 
-const v1 = {}
 const v2 = {}
 const v3 = {}
 
@@ -179,7 +178,7 @@ const getGrant = (protocolVersion) => (runtime) => {
       let userAgent = request.headers['user-agent']
       let userAgentIsChrome = userAgent.split('Chrome/').length > 1
       if (userAgentIsChrome) {
-        let chromeVersion = parseInt(userAgent.split('Chrome/')[1].substring(0,2)) 
+        let chromeVersion = parseInt(userAgent.split('Chrome/')[1].substring(0, 2))
         if (chromeVersion < 70) {
           return reply(boom.notFound('promotion not available for browser-laptop.'))
         }

--- a/ledger/controllers/grants.js
+++ b/ledger/controllers/grants.js
@@ -179,7 +179,6 @@ v3.all = {
 }
 
 /*
-   GET /v1/grants
    GET /v2/grants
    GET /v3/grants
  */
@@ -273,24 +272,6 @@ const getGrant = (protocolVersion) => (runtime) => {
     l10n(promotion)
 
     reply(underscore.omit(promotion, [ '_id', 'priority', 'active', 'count', 'batchId', 'timestamp' ]))
-  }
-}
-v1.read = {
-  handler: getGrant(1),
-  description: 'See if a v1 promotion is available',
-  tags: [ 'api' ],
-
-  validate: {
-    query: {
-      lang: Joi.string().regex(localeRegExp).optional().default('en').description('the l10n language'),
-      paymentId: Joi.string().guid().optional().description('identity of the wallet')
-    }
-  },
-
-  response: {
-    schema: Joi.object().keys({
-      promotionId: Joi.string().required().description('the promotion-identifier')
-    }).unknown(true).description('promotion properties')
   }
 }
 
@@ -910,7 +891,6 @@ module.exports.routes = [
   braveHapi.routes.async().path('/v1/promotions').config(v1.all),
   braveHapi.routes.async().path('/v2/promotions').config(v2.all),
   braveHapi.routes.async().path('/v3/promotions').config(v3.all),
-  braveHapi.routes.async().path('/v1/grants').config(v1.read),
   braveHapi.routes.async().path('/v2/grants').config(v2.read),
   braveHapi.routes.async().path('/v3/grants').config(v3.read),
   braveHapi.routes.async().put().path('/v1/grants/{paymentId}').config(v1.claimGrant),

--- a/ledger/controllers/grants.js
+++ b/ledger/controllers/grants.js
@@ -710,7 +710,6 @@ v2.cohorts = { handler: (runtime) => {
 }
 
 /*
-   GET /v1/captchas/{paymentId}
    GET /v2/captchas/{paymentId}
  */
 
@@ -727,10 +726,6 @@ const getCaptcha = (protocolVersion) => (runtime) => {
     if (!wallet) return reply(boom.notFound('no such wallet: ' + paymentId))
 
     const productEndpoints = {
-      'browser-laptop': {
-        1: '/v1/captchas/target',
-        2: '/v1/captchas/colortarget'
-      },
       'brave-core': {
         2: '/v2/captchas/colortarget'
       }
@@ -760,23 +755,6 @@ const getCaptcha = (protocolVersion) => (runtime) => {
     await wallets.findOneAndUpdate({ 'paymentId': paymentId }, { $set: { captcha: underscore.extend(solution, {version: protocolVersion}) } })
 
     return reply(payload).header('Content-Type', headers['content-type']).header('Captcha-Hint', headers['captcha-hint'])
-  }
-}
-
-v1.getCaptcha = {
-  handler: getCaptcha(1),
-  description: 'Get a claim time captcha',
-  tags: [ 'api' ],
-
-  plugins: {
-    rateLimit: {
-      enabled: rateLimitEnabled && !qalist.addresses,
-      rate: (request) => captchaRate
-    }
-  },
-
-  validate: {
-    params: { paymentId: Joi.string().guid().required().description('identity of the wallet') }
   }
 }
 
@@ -861,7 +839,6 @@ module.exports.routes = [
   braveHapi.routes.async().post().path('/v2/grants').config(v2.create),
   braveHapi.routes.async().path('/v1/attestations/{paymentId}').config(v3.attestations),
   braveHapi.routes.async().put().path('/v2/grants/cohorts').config(v2.cohorts),
-  braveHapi.routes.async().path('/v1/captchas/{paymentId}').config(v1.getCaptcha),
   braveHapi.routes.async().path('/v2/captchas/{paymentId}').config(v2.getCaptcha)
 ]
 

--- a/ledger/controllers/grants.js
+++ b/ledger/controllers/grants.js
@@ -564,7 +564,7 @@ const grantsUploadSchema = {
    POST /v2/grants
 */
 
-const uploadGrants = function (runtime) {
+const uploadGrants = (protocolVersion) => (runtime) => {
   return async (request, reply) => {
     const batchId = uuid.v4().toLowerCase()
     const debug = braveHapi.debug(module, request)
@@ -600,7 +600,6 @@ const uploadGrants = function (runtime) {
     await grants.insert(grantsToInsert)
 
     for (let entry of payload.promotions) {
-      let protocolVersion = 1
       let $set = underscore.assign({
         protocolVersion
       }, underscore.omit(entry, ['promotionId']))
@@ -620,7 +619,7 @@ const uploadGrants = function (runtime) {
 }
 
 v2.create =
-{ handler: uploadGrants,
+{ handler: uploadGrants(2),
 
   auth: {
     strategy: 'session',

--- a/ledger/controllers/grants.js
+++ b/ledger/controllers/grants.js
@@ -538,7 +538,7 @@ async function captchaCheck (debug, runtime, request, promotion, wallet) {
         return boom.forbidden('must first request correct captcha version')
       }
     } else {
-      if (promotion.protocolVersion !== 1) {
+      if (promotion.protocolVersion !== 2) {
         return boom.forbidden('must first request correct captcha version')
       }
     }
@@ -879,12 +879,12 @@ module.exports.initialize = async (debug, runtime) => {
         batchId: '',
         timestamp: bson.Timestamp.ZERO,
 
-        protocolVersion: 1
+        protocolVersion: 2
       },
       unique: [ { promotionId: 1 } ],
       others: [ { active: 1 }, { count: 1 },
                 { batchId: 1 }, { timestamp: 1 },
-                { protocolVersion: 1 } ]
+                { protocolVersion: 2 } ]
     }
   ])
 

--- a/ledger/controllers/grants.js
+++ b/ledger/controllers/grants.js
@@ -66,7 +66,6 @@ const qaOnlyP = (request) => {
 }
 
 /*
-   GET /v1/promotions
    GET /v2/promotions
    GET /v3/promotions
  */
@@ -141,18 +140,6 @@ const safetynetPassthrough = (handler) => (runtime) => async (request, reply) =>
 const promotionsGetResponseSchema = Joi.array().min(0).items(Joi.object().keys({
   promotionId: Joi.string().required().description('the promotion-identifier')
 }).unknown(true).description('promotion properties'))
-
-v1.all = {
-  handler: getPromotions(1),
-  description: 'See if a v1 promotion is available',
-  tags: [ 'api' ],
-
-  validate: { query: {} },
-
-  response: {
-    schema: promotionsGetResponseSchema
-  }
-}
 
 v2.all = {
   handler: getPromotions(2),
@@ -327,11 +314,10 @@ const checkBounds = (v1, v2, tol) => {
 }
 
 /*
-   PUT /v1/grants/{paymentId}
    PUT /v2/grants/{paymentId}
  */
 
-v1.claimGrant = {
+v2.claimGrant = {
   handler: claimGrant(captchaCheck),
   description: 'Request a grant for a wallet',
   tags: [ 'api' ],
@@ -358,7 +344,6 @@ v1.claimGrant = {
     schema: joiGrantSubset
   }
 }
-v2.claimGrant = v1.claimGrant
 
 /*
    PUT /v3/grants/{paymentId}
@@ -576,7 +561,6 @@ const grantsUploadSchema = {
 }
 
 /*
-   POST /v1/grants
    POST /v2/grants
 */
 
@@ -633,26 +617,6 @@ const uploadGrants = function (runtime) {
 
     reply({})
   }
-}
-
-v1.create =
-{ handler: uploadGrants,
-
-  auth: {
-    strategy: 'session',
-    scope: [ 'ledger' ],
-    mode: 'required'
-  },
-
-  description: 'Create one or more grants',
-  tags: [ 'api' ],
-
-  validate: { payload: Joi.object().keys(grantsUploadSchema).required().description('data for bulk upload') },
-
-  payload: { output: 'data', maxBytes: 1024 * 1024 * 20 },
-
-  response:
-    { schema: Joi.object().length(0) }
 }
 
 v2.create =
@@ -888,15 +852,12 @@ v3.attestations = {
 }
 
 module.exports.routes = [
-  braveHapi.routes.async().path('/v1/promotions').config(v1.all),
   braveHapi.routes.async().path('/v2/promotions').config(v2.all),
   braveHapi.routes.async().path('/v3/promotions').config(v3.all),
   braveHapi.routes.async().path('/v2/grants').config(v2.read),
   braveHapi.routes.async().path('/v3/grants').config(v3.read),
-  braveHapi.routes.async().put().path('/v1/grants/{paymentId}').config(v1.claimGrant),
   braveHapi.routes.async().put().path('/v2/grants/{paymentId}').config(v2.claimGrant),
   braveHapi.routes.async().put().path('/v3/grants/{paymentId}').config(v3.claimGrant),
-  braveHapi.routes.async().post().path('/v1/grants').config(v1.create),
   braveHapi.routes.async().post().path('/v2/grants').config(v2.create),
   braveHapi.routes.async().path('/v1/attestations/{paymentId}').config(v3.attestations),
   braveHapi.routes.async().put().path('/v2/grants/cohorts').config(v2.cohorts),

--- a/test/e2e.integration.test.js
+++ b/test/e2e.integration.test.js
@@ -101,7 +101,6 @@ test('ledger: create a surveyor', async t => {
   t.not(prevSurveyorId, surveyorId)
 })
 
-
 test('ledger: create promotion', async t => {
   t.plan(0)
   const grants = {

--- a/test/e2e.integration.test.js
+++ b/test/e2e.integration.test.js
@@ -101,12 +101,12 @@ test('ledger: create a surveyor', async t => {
   t.not(prevSurveyorId, surveyorId)
 })
 
+const grants = {
+  'grants': [ 'eyJhbGciOiJFZERTQSIsImtpZCI6IiJ9.eyJhbHRjdXJyZW5jeSI6IkJBVCIsImdyYW50SWQiOiJhNDMyNjg1My04NzVlLTQ3MDgtYjhkNS00M2IwNGMwM2ZmZTgiLCJwcm9iaSI6IjMwMDAwMDAwMDAwMDAwMDAwMDAwIiwicHJvbW90aW9uSWQiOiI5MDJlN2U0ZC1jMmRlLTRkNWQtYWFhMy1lZThmZWU2OWY3ZjMiLCJtYXR1cml0eVRpbWUiOjE1MTUwMjkzNTMsImV4cGlyeVRpbWUiOjE4MzAzODkzNTN9.8M5dpr_rdyCURd7KBc4GYaFDsiDEyutVqG-mj1QRk7BCiihianvhiqYeEnxMf-F4OU0wWyCN5qKDTxeqait_BQ' ],
+  'promotions': [{'active': true, 'priority': 0, 'promotionId': '902e7e4d-c2de-4d5d-aaa3-ee8fee69f7f3'}]
+}
 test('ledger: create promotion', async t => {
   t.plan(0)
-  const grants = {
-    'grants': [ 'eyJhbGciOiJFZERTQSIsImtpZCI6IiJ9.eyJhbHRjdXJyZW5jeSI6IkJBVCIsImdyYW50SWQiOiJhNDMyNjg1My04NzVlLTQ3MDgtYjhkNS00M2IwNGMwM2ZmZTgiLCJwcm9iaSI6IjMwMDAwMDAwMDAwMDAwMDAwMDAwIiwicHJvbW90aW9uSWQiOiI5MDJlN2U0ZC1jMmRlLTRkNWQtYWFhMy1lZThmZWU2OWY3ZjMiLCJtYXR1cml0eVRpbWUiOjE1MTUwMjkzNTMsImV4cGlyeVRpbWUiOjE4MzAzODkzNTN9.8M5dpr_rdyCURd7KBc4GYaFDsiDEyutVqG-mj1QRk7BCiihianvhiqYeEnxMf-F4OU0wWyCN5qKDTxeqait_BQ' ],
-    'promotions': [{'active': true, 'priority': 0, 'promotionId': '902e7e4d-c2de-4d5d-aaa3-ee8fee69f7f3'}]
-  }
   const url = '/v2/grants'
   // valid grant
   await ledgerAgent.post(url).send(grants).expect(ok)

--- a/test/e2e.integration.test.js
+++ b/test/e2e.integration.test.js
@@ -101,14 +101,14 @@ test('ledger: create a surveyor', async t => {
   t.not(prevSurveyorId, surveyorId)
 })
 
-const grants = {
-  'grants': [ 'eyJhbGciOiJFZERTQSIsImtpZCI6IiJ9.eyJhbHRjdXJyZW5jeSI6IkJBVCIsImdyYW50SWQiOiJhNDMyNjg1My04NzVlLTQ3MDgtYjhkNS00M2IwNGMwM2ZmZTgiLCJwcm9iaSI6IjMwMDAwMDAwMDAwMDAwMDAwMDAwIiwicHJvbW90aW9uSWQiOiI5MDJlN2U0ZC1jMmRlLTRkNWQtYWFhMy1lZThmZWU2OWY3ZjMiLCJtYXR1cml0eVRpbWUiOjE1MTUwMjkzNTMsImV4cGlyeVRpbWUiOjE4MzAzODkzNTN9.8M5dpr_rdyCURd7KBc4GYaFDsiDEyutVqG-mj1QRk7BCiihianvhiqYeEnxMf-F4OU0wWyCN5qKDTxeqait_BQ' ],
-  'promotions': [{'active': true, 'priority': 0, 'promotionId': '902e7e4d-c2de-4d5d-aaa3-ee8fee69f7f3'}]
-}
 
 test('ledger: create promotion', async t => {
   t.plan(0)
-  const url = '/v1/grants'
+  const grants = {
+    'grants': [ 'eyJhbGciOiJFZERTQSIsImtpZCI6IiJ9.eyJhbHRjdXJyZW5jeSI6IkJBVCIsImdyYW50SWQiOiJhNDMyNjg1My04NzVlLTQ3MDgtYjhkNS00M2IwNGMwM2ZmZTgiLCJwcm9iaSI6IjMwMDAwMDAwMDAwMDAwMDAwMDAwIiwicHJvbW90aW9uSWQiOiI5MDJlN2U0ZC1jMmRlLTRkNWQtYWFhMy1lZThmZWU2OWY3ZjMiLCJtYXR1cml0eVRpbWUiOjE1MTUwMjkzNTMsImV4cGlyeVRpbWUiOjE4MzAzODkzNTN9.8M5dpr_rdyCURd7KBc4GYaFDsiDEyutVqG-mj1QRk7BCiihianvhiqYeEnxMf-F4OU0wWyCN5qKDTxeqait_BQ' ],
+    'promotions': [{'active': true, 'priority': 0, 'promotionId': '902e7e4d-c2de-4d5d-aaa3-ee8fee69f7f3'}]
+  }
+  const url = '/v2/grants'
   // valid grant
   await ledgerAgent.post(url).send(grants).expect(ok)
 })
@@ -368,7 +368,7 @@ test('ledger : v2 contribution workflow with uphold BAT wallet', async t => {
 })
 
 test('ledger: v2 grant contribution workflow with uphold BAT wallet', async t => {
-  const url = '/v1/grants'
+  const url = '/v2/grants'
   // valid grant
   const promotionId = 'b91d63c7-b6d1-43e2-8ef2-c3f9bf0b1010'
   const grants = {'grants': ['eyJhbGciOiJFZERTQSIsImtpZCI6IiJ9.eyJhbHRjdXJyZW5jeSI6IkJBVCIsImdyYW50SWQiOiIxODg0NTI0Ny1jZjQyLTQzZjctOWNkZS0yMThhYTU1ZjQwMGIiLCJwcm9iaSI6IjMwMDAwMDAwMDAwMDAwMDAwMDAwIiwicHJvbW90aW9uSWQiOiJiOTFkNjNjNy1iNmQxLTQzZTItOGVmMi1jM2Y5YmYwYjEwMTAiLCJtYXR1cml0eVRpbWUiOjE1MzgzNTIwMDAsImV4cGlyeVRpbWUiOjE2NTE5NjgwMDB9.iz8fpszEHsRhbsNvnQ1aKYz8nlSmZ9Wb9gR6kKS2DR2RJa18mH-KIhEqSMUoWX6stBNCbQwcwjtmdBiIVmRcBg'], 'promotions': [{promotionId, 'priority': 0, 'active': true, 'minimumReconcileTimestamp': 1538352000000, 'protocolVersion': 2}]}
@@ -451,6 +451,7 @@ test('ledger: v2 grant contribution workflow with uphold BAT wallet', async t =>
 
   await ledgerAgent
     .get(`/v2/captchas/${paymentId}`)
+    .set('brave-product', 'brave-core')
     .expect(ok)
 
   const ledgerDB = await connectToDb('ledger')

--- a/test/ledger/grants.integration.test.js
+++ b/test/ledger/grants.integration.test.js
@@ -185,8 +185,7 @@ test('get /v2/grants returns 404 for browser-laptop', async (t) => {
       .expect(404)
   t.is(response.body.message, 'promotion not available for browser-laptop.', 'identifies and rejects browser-laptop')
 
-
-  var response = await ledgerAgent
+  response = await ledgerAgent
       .get(`/v2/grants`)
       .set('user-agent', braveCoreUserAgent)
       .expect(404)

--- a/test/ledger/grants.integration.test.js
+++ b/test/ledger/grants.integration.test.js
@@ -174,6 +174,24 @@ test('attestation returns a random value for the same paymentId', async (t) => {
   t.not(body.nonce, second.nonce)
 })
 
+test('get /v2/grants returns 404 for browser-laptop', async (t) => {
+
+  const browserLaptopUserAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69 Safari/537.36'
+  const braveCoreUserAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3581.0 Safari/537.36'
+  var response = await ledgerAgent
+      .get(`/v2/grants`)
+      .set('user-agent', browserLaptopUserAgent)
+      .expect(404)
+  t.is(response.body.message, 'promotion not available for browser-laptop.', 'identifies and rejects browser-laptop')
+
+
+  var response = await ledgerAgent
+      .get(`/v2/grants`)
+      .set('user-agent', braveCoreUserAgent)
+      .expect(404)
+  t.not(response.body.message, 'promotion not available for browser-laptop.', 'does not reject browser-laptop')
+})
+
 test('claim grants with attestations', async (t) => {
   // t.plan(10)
   t.true(true)

--- a/test/ledger/grants.integration.test.js
+++ b/test/ledger/grants.integration.test.js
@@ -71,7 +71,6 @@ test('grants: add expired grant and make sure it does not add to wallet', async 
   // get available grant
   await ledgerAgent
     .get('/v2/grants')
-    // .set('user-agent', 'Chrome/72')
     .expect(ok)
 
   await ledgerAgent

--- a/test/ledger/grants.integration.test.js
+++ b/test/ledger/grants.integration.test.js
@@ -175,7 +175,6 @@ test('attestation returns a random value for the same paymentId', async (t) => {
 })
 
 test('get /v2/grants returns 404 for browser-laptop', async (t) => {
-
   const browserLaptopUserAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69 Safari/537.36'
   const braveCoreUserAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3581.0 Safari/537.36'
   var response = await ledgerAgent


### PR DESCRIPTION
Resolves #502
Supercedes #503

Reject the requests to GET /v2/grants made by browsers running a chrome version < 70.

Remove
* GET /v1/promotions
* PUT /v1/grants/{paymentId}'
* POST /v1/grants
* GET /v1/captchas/{payment_id}
* GET /v1/grants