### PR TITLE
[WIP] Expose endpoint to publishers for inserting manual transactions

### DIFF
--- a/eyeshade/controllers/accounts.js
+++ b/eyeshade/controllers/accounts.js
@@ -383,7 +383,7 @@ v1.manualTransaction = {
   handler: (runtime) => async (request, reply) => {
     const { params, payload } = request
     const { postgres } = runtime
-    const { account_id, transaction_type, payment_id } = params
+    const { account_id, payment_id } = params
     const { amount } = payload
 
     let txs = await transactions.insertFromManual(runtime, postgres, payment_id, account_id, amount)
@@ -423,7 +423,7 @@ v1.manualTransaction = {
       from_account: Joi.string().guid().required(),
       to_account_type: Joi.string().required().valid(['owner']),
       to_account: braveJoi.string().owner().required(),
-      amount: Joi.number().required().description('amount in BAT'),
+      amount: Joi.number().required().description('amount in BAT')
     }))
   }
 }

--- a/eyeshade/lib/transaction.js
+++ b/eyeshade/lib/transaction.js
@@ -12,6 +12,7 @@ const SETTLEMENT_NAMESPACE = {
 }
 
 module.exports = {
+  insertFromManual,
   insertFromSettlement,
   insertFromVoting,
   insertFromReferrals,
@@ -53,6 +54,35 @@ function monthsFromSeconds (created) {
 
 function seconds () {
   return +(new Date()) / 1000
+}
+
+async function insertFromManual (runtime, client, paymentId, toAccount, amount) {
+  const createdAt = (new Date).getTime()
+  const description = 'manual payout to partner'
+  const transactionType = 'manual'
+  const fromAccount = process.env.BAT_SETTLEMENT_ADDRESS
+  const fromAccountType = 'uphold'
+  const toAccountType = 'owner'
+
+  const insertTransactionQuery = `
+    insert into transactions ( id, created_at, description, transaction_type, from_account, from_account_type, to_account, to_account_type, amount )
+    VALUES ( $1, to_timestamp($2), $3, $4, $5, $6, $7, $8, $9 )
+    RETURNING *;
+  `
+
+  const { rows } = await client.query(insertTransactionQuery, [
+    paymentId,
+    createdAt,
+    description,
+    transactionType,
+    fromAccount,
+    fromAccountType,
+    toAccount,
+    toAccountType,
+    amount,
+  ])
+
+  return rows
 }
 
 async function insertFromSettlement (runtime, client, settlement) {

--- a/eyeshade/lib/transaction.js
+++ b/eyeshade/lib/transaction.js
@@ -57,7 +57,7 @@ function seconds () {
 }
 
 async function insertFromManual (runtime, client, paymentId, toAccount, amount) {
-  const createdAt = (new Date).getTime()
+  const createdAt = (new Date()).getTime()
   const description = 'manual payout to partner'
   const transactionType = 'manual'
   const fromAccount = process.env.BAT_SETTLEMENT_ADDRESS
@@ -79,7 +79,7 @@ async function insertFromManual (runtime, client, paymentId, toAccount, amount) 
     fromAccountType,
     toAccount,
     toAccountType,
-    amount,
+    amount
   ])
 
   return rows

--- a/test/eyeshade/accounts.integration.test.js
+++ b/test/eyeshade/accounts.integration.test.js
@@ -238,3 +238,28 @@ test('ads payment api inserts a transaction into the table and errs on subsequen
     .send(payload)
     .expect(409)
 })
+
+test('Publishers can insert manual transactions', async(t) => {
+  const ownerId = 'publishers#uuid:' + uuid.v4().toLowerCase()
+  const paymentId = uuid.v4().toLowerCase()
+  const url = `/v1/accounts/owner/${encodeURIComponent(ownerId)}/transactions/manual/${paymentId}`
+  const payload = {
+    amount: 50
+  }
+
+  const response = await eyeshadeAgent
+    .put(url)
+    .send(payload)
+    .expect(200)
+
+  t.true(response.body.length === 1)
+  const transaction = response.body[0]
+  t.true(Object.keys(transaction).length === 9)
+  t.true(transaction['id'] === paymentId)
+  t.true(transaction['description'] === 'manual payout to partner')
+  t.true(transaction['from_account_type'] === 'uphold')
+  t.true(transaction['from_account'] === process.env.BAT_SETTLEMENT_ADDRESS)
+  t.true(transaction['to_account_type'] === 'owner')
+  t.true(transaction['to_account'] === ownerId)
+  t.true(transaction['amount'] === '50.000000000000000000')
+})


### PR DESCRIPTION
Resolves #518 

Expose an endpoint
```
PUT /v1/accounts/{account_type}/{account_id}/transactions/{transaction_type}/{transaction_id}
```
to publishers that inserts a transaction from the settlement wallet address to the owner identifier.

All transactions will have type `manual`, be from the settlement wallet, and to an owner account that publishers supplies.

At the moment we only accept `account_types` that are `owners`, and transaction types that are `manual`, so we might not want to generalize those as variables in the endpoint uri.
