### PR TITLE
Allow Publishers to post manual settlement transactions

### DIFF
--- a/eyeshade/controllers/publishers.js
+++ b/eyeshade/controllers/publishers.js
@@ -59,7 +59,7 @@ v2.settlement = {
   validate: {
     payload: Joi.array().min(1).items(Joi.object().keys({
       owner: braveJoi.string().owner().required().description('the owner identity'),
-      publisher: braveJoi.string().publisher().optional().description('the publisher identity'), // TODO make publisher required when type != 'manual'
+      publisher: braveJoi.string().publisher().when('type', { is: Joi.string().valid('manual'), then: Joi.optional().allow(''), otherwise: Joi.required() }).description('the publisher identity'),
       address: Joi.string().guid().required().description('settlement address'),
       altcurrency: braveJoi.string().altcurrencyCode().required().description('the altcurrency'),
       probi: braveJoi.string().numeric().required().description('the settlement in probi'),

--- a/eyeshade/controllers/publishers.js
+++ b/eyeshade/controllers/publishers.js
@@ -37,20 +37,19 @@ v2.settlement = {
         entry.commission = new BigNumber(entry.commission).plus(new BigNumber(entry.fee)).toString()
         fields.forEach((field) => { state.$set[field] = bson.Decimal128.fromString(entry[field].toString()) })
         underscore.extend(state.$set,
-                          underscore.pick(entry, [ 'address', 'altcurrency', 'currency', 'hash', 'type', 'owner' ]))
+                          underscore.pick(entry, [ 'address', 'altcurrency', 'currency', 'hash', 'type', 'owner', 'documentId' ]))
 
         await settlements.update({ settlementId: entry.transactionId, publisher: entry.publisher }, state, { upsert: true })
       }
 
       await runtime.queue.send(debug, 'settlement-report', { settlementId: entry.transactionId, shouldUpdateBalances: true })
-
       reply({})
     }
   },
 
   auth: {
-    strategy: 'session',
-    scope: [ 'ledger' ],
+    strategies: ['session', 'simple-scoped-token'],
+    scope: ['ledger', 'publishers'],
     mode: 'required'
   },
 
@@ -60,7 +59,7 @@ v2.settlement = {
   validate: {
     payload: Joi.array().min(1).items(Joi.object().keys({
       owner: braveJoi.string().owner().required().description('the owner identity'),
-      publisher: braveJoi.string().publisher().required().description('the publisher identity'),
+      publisher: braveJoi.string().publisher().optional().description('the publisher identity'), // TODO make publisher required when type != 'manual'
       address: Joi.string().guid().required().description('settlement address'),
       altcurrency: braveJoi.string().altcurrencyCode().required().description('the altcurrency'),
       probi: braveJoi.string().numeric().required().description('the settlement in probi'),
@@ -70,7 +69,7 @@ v2.settlement = {
       commission: braveJoi.string().numeric().default('0.00').description('settlement commission'),
       fee: braveJoi.string().numeric().default('0.00').description('fee in addition to settlement commission'),
       transactionId: Joi.string().guid().required().description('the transactionId'),
-      type: Joi.string().valid('contribution', 'referral').default('contribution').description('settlement input'),
+      type: Joi.string().valid('contribution', 'referral', 'manual').default('contribution').description('settlement input'),
       hash: Joi.string().guid().required().description('settlement-identifier')
     }).unknown(true)).required().description('publisher settlement report')
   },

--- a/eyeshade/lib/transaction.js
+++ b/eyeshade/lib/transaction.js
@@ -1,4 +1,3 @@
-
 const BigNumber = require('bignumber.js')
 const getPublisherProps = require('bat-publisher').getPublisherProps
 const uuidv5 = require('uuid/v5')

--- a/eyeshade/migrations/0004_manual_settlements/down.sql
+++ b/eyeshade/migrations/0004_manual_settlements/down.sql
@@ -1,0 +1,3 @@
+alter table transactions drop constraint check_transaction_type;
+alter table transactions add constraint check_transaction_type
+  check (transaction_type in ('contribution', 'referral', 'contribution_settlement', 'referral_settlement', 'fees', 'scaleup', 'manual', 'ad', 'ad_settlement'));

--- a/eyeshade/migrations/0004_manual_settlements/up.sql
+++ b/eyeshade/migrations/0004_manual_settlements/up.sql
@@ -1,0 +1,3 @@
+alter table transactions drop constraint check_transaction_type;
+alter table transactions add constraint check_transaction_type
+  check (transaction_type in ('contribution', 'referral', 'contribution_settlement', 'referral_settlement', 'fees', 'scaleup', 'manual', 'ad', 'ad_settlement', 'manual_settlement'));

--- a/eyeshade/workers/publishers.js
+++ b/eyeshade/workers/publishers.js
@@ -6,7 +6,7 @@ exports.initialize = async (debug, runtime) => {
 }
 
 exports.workers = {
-/* sent by POST /v1/publishers/settlement
+/* sent by POST /v2/publishers/settlement
 
     { queue            : 'settlement-report'
     , message          :
@@ -18,7 +18,6 @@ exports.workers = {
       const settlements = runtime.database.get('settlements', debug)
       const { settlementId, shouldUpdateBalances } = payload
       const docs = await settlements.find({ settlementId, owner: { $exists: true } })
-
       const client = await runtime.postgres.connect()
       try {
         await client.query('BEGIN')

--- a/test/eyeshade/publishers.integration.test.js
+++ b/test/eyeshade/publishers.integration.test.js
@@ -16,9 +16,9 @@ import Postgres from 'bat-utils/lib/runtime-postgres'
 
 const postgres = new Postgres({ postgres: { url: process.env.BAT_POSTGRES_URL } })
 
-test.afterEach(t => {
-  cleanPgDb(postgres)()
-  cleanDbs()
+test.afterEach.always(async t => {
+  await cleanPgDb(postgres)()
+  await cleanDbs()
 })
 
 test('unauthed requests cannot post settlement', async t => {

--- a/test/eyeshade/publishers.integration.test.js
+++ b/test/eyeshade/publishers.integration.test.js
@@ -1,0 +1,102 @@
+'use strict'
+
+import { serial as test } from 'ava'
+import uuid from 'uuid'
+import {
+  cleanDbs,
+  cleanPgDb,
+  eyeshadeAgent,
+  connectToDb
+} from '../utils'
+import {
+  timeout
+} from 'bat-utils/lib/extras-utils'
+import { agent } from 'supertest'
+import Postgres from 'bat-utils/lib/runtime-postgres'
+
+const postgres = new Postgres({ postgres: { url: process.env.BAT_POSTGRES_URL } })
+
+test.afterEach(t => {
+  cleanPgDb(postgres)()
+  cleanDbs()
+})
+
+test('unauthed requests cannot post settlement', async t => {
+  const unauthedAgent = agent(process.env.BAT_EYESHADE_SERVER)
+  const url = `/v2/publishers/settlement`
+  const response = await unauthedAgent.post(url).send({}).expect(401)
+  t.true(response.status === 401)
+})
+
+test('can post a manual settlement from publisher app using token auth', async t => {
+  const url = `/v2/publishers/settlement`
+  const eyeshadeMongo = await connectToDb('eyeshade')
+  const settlements = eyeshadeMongo.collection('settlements')
+  const client = await postgres.connect()
+
+  const manualSettlement = {
+    owner: 'publishers#uuid:' + uuid.v4().toLowerCase(),
+    publisher: 'lol',
+    address: uuid.v4().toLowerCase(),
+    altcurrency: 'BAT',
+    probi: '5000000000000000000',
+    fees: '0',
+    currency: 'BAT',
+    amount: '5',
+    commission: '0.0',
+    transactionId: uuid.v4().toLowerCase(),
+    type: 'manual',
+    documentId: uuid.v4().toLowerCase(),
+    hash: uuid.v4().toLowerCase()
+  }
+
+  await eyeshadeAgent.post(url).send([manualSettlement]).expect(200)
+
+  // ensure the manual settlement doc was created with the document id
+  const settlementDoc = await settlements.findOne({settlementId: manualSettlement.transactionId})
+  t.true(settlementDoc.type === 'manual')
+  t.true(settlementDoc.documentId === manualSettlement.documentId)
+
+  // ensure both transactions were entered into transactions table
+  const manualTxsQuery = `select * from transactions where transaction_type = 'manual';`
+  const manualSettlementTxQuery = `select * from transactions where transaction_type = 'manual_settlement';`
+
+  let rows
+  do { // wait until settlement-report is processed and transactions are entered into postgres
+    await timeout(500).then(async () => {
+      rows = (await client.query(manualTxsQuery)).rows
+    })
+  } while (rows.length === 0)
+
+  const manualTx = rows[0]
+  t.true(rows.length === 1)
+
+  rows = (await client.query(manualSettlementTxQuery)).rows
+  t.true(rows.length === 1)
+  const manualSettlementTx = rows[0]
+
+  t.true(manualTx.description === 'handshake agreement with business developement')
+  t.true(manualTx.document_id === manualSettlement.documentId)
+  t.true(manualTx.transaction_type === 'manual')
+  t.true(manualTx.from_account_type === 'uphold')
+  t.true(manualTx.from_account === process.env.BAT_SETTLEMENT_ADDRESS)
+  t.true(manualTx.to_account_type === 'owner')
+  t.true(manualTx.to_account === manualSettlement.owner)
+  t.true(manualTx.amount === '5.000000000000000000')
+  t.true(manualTx.channel === null)
+  t.true(manualTx.settlement_currency === null)
+  t.true(manualTx.settlement_amount === null)
+
+  t.true(manualSettlementTx.description === 'payout for manual')
+  t.true(manualSettlementTx.document_id === manualSettlement.documentId)
+  t.true(manualSettlementTx.transaction_type === 'manual_settlement')
+  t.true(manualSettlementTx.from_account_type === 'owner')
+  t.true(manualSettlementTx.from_account === manualSettlement.owner)
+  t.true(manualSettlementTx.to_account_type === 'uphold')
+  t.true(manualSettlementTx.to_account === manualSettlement.address)
+  t.true(manualSettlementTx.amount === '5.000000000000000000')
+  t.true(manualSettlementTx.settlement_currency === 'BAT')
+  t.true(manualSettlementTx.settlement_amount === '5.000000000000000000')
+
+  t.true(manualTx.to_account === manualSettlementTx.from_account)
+})

--- a/test/eyeshade/publishers.integration.test.js
+++ b/test/eyeshade/publishers.integration.test.js
@@ -28,6 +28,28 @@ test('unauthed requests cannot post settlement', async t => {
   t.true(response.status === 401)
 })
 
+test('cannot post payouts if the publisher field is blank and type is not manual', async t => {
+  const url = `/v2/publishers/settlement`
+  const manualSettlement = {
+    owner: 'publishers#uuid:' + uuid.v4().toLowerCase(),
+    publisher: '',
+    address: uuid.v4().toLowerCase(),
+    altcurrency: 'BAT',
+    probi: '5000000000000000000',
+    fees: '0',
+    currency: 'BAT',
+    amount: '5',
+    commission: '0.0',
+    transactionId: uuid.v4().toLowerCase(),
+    type: 'contribution',
+    documentId: uuid.v4().toLowerCase(),
+    hash: uuid.v4().toLowerCase()
+  }
+
+  const reponse = await eyeshadeAgent.post(url).send([manualSettlement])
+  t.true(reponse.status === 400)
+})
+
 test('can post a manual settlement from publisher app using token auth', async t => {
   const url = `/v2/publishers/settlement`
   const eyeshadeMongo = await connectToDb('eyeshade')
@@ -36,7 +58,7 @@ test('can post a manual settlement from publisher app using token auth', async t
 
   const manualSettlement = {
     owner: 'publishers#uuid:' + uuid.v4().toLowerCase(),
-    publisher: 'lol',
+    publisher: '',
     address: uuid.v4().toLowerCase(),
     altcurrency: 'BAT',
     probi: '5000000000000000000',


### PR DESCRIPTION
Resolves #519 
Enabled by https://github.com/brave-intl/bat-go/pull/59
* Expand transaction_type constraint to include 'manual_settlement'

* Expose POST /v2/publishers/settlement to pub app via token based auth

* Add logic to insert manual and manual_settlement transactions in settlement-report job