### PR TITLE
Increment referral_confirmations_counter on prometheus as confirmations come in

### DIFF
--- a/eyeshade/workers/referrals.js
+++ b/eyeshade/workers/referrals.js
@@ -59,6 +59,14 @@ exports.workers = {
         await client.query('COMMIT')
       } finally {
         client.release()
+        // Update prometheus counter
+        const Prometheus = require('../../bat-utils/lib/runtime-prometheus')
+        const prometheus = new Prometheus({
+          prometheus: {
+            label: process.env.SERVICE + '.' + process.env.DYNO,
+            redis: process.env.REDIS2_URL || process.env.REDIS_URL
+        }}, runtime)
+        await prometheus.incrCounter('referral_confirmations_counter', 'this is the help parameter', docs.length)
       }
     }
 }


### PR DESCRIPTION
I've spent a couple hours without making much progress on this issue, so opening a draft PR to share my status.

I think we want implement a counter on prometheus that increments when a referral confirmation is entered into the transaction table.  We should be able to create some alerts around this metric when the counter hasn't incremented in awhile, but that won't be done with code changes.

When I actually try to increment this counter with
```
await prometheus.incrCounter('referral_confirmations_counter', 'this is the help parameter', docs.length)
```
I get an error saying the counter has already been created
```
Error: A metric with the name referral_confirmations_counter has already been registered.
```
Which seems odd since I'm only trying to increment the counter.

Regardless, I don't see the counter metric available on the prometheus web ui:

![image](https://user-images.githubusercontent.com/12549658/54564082-49e7c880-49a1-11e9-9948-bc9749e87e35.png)

I've tried various things including not using the class in the runtime-prometheus file and following the [documentation for the counter](https://github.com/siimon/prom-client#counter) directly with the same results.

🤔 