### PR TITLE
Surveyor updated at tsmp

### DIFF
--- a/eyeshade/workers/reports.js
+++ b/eyeshade/workers/reports.js
@@ -38,7 +38,7 @@ async function freezeOldSurveyors (debug, runtime, olderThanDays) {
   }
 
   const query = `
-  update surveyor_groups set frozen = true
+  update surveyor_groups set frozen = true, updated_at = current_timestamp
   where not frozen and created_at < current_date - $1 * interval '1d'
   returning id;
   `


### PR DESCRIPTION
noticed that updated_at was not being set on surveyors at frozen. may also be worthwhile to do on votes in the worker, depending on what we want the updated_at value to be for votes