### PR TITLE
add default dyno label

### DIFF
--- a/bat-utils/lib/runtime-prometheus.js
+++ b/bat-utils/lib/runtime-prometheus.js
@@ -23,6 +23,9 @@ function Prometheus (config, runtime) {
   this.shared = {}
   this.listenerId = `${listenerPrefix}${this.config.label}`
 
+  const defaultLabels = { dyno: this.config.label }
+  this.register.setDefaultLabels(defaultLabels)
+
   const timeout = 10000
   this.timeout = timeout
   setInterval(() => this.maintenance(), timeout)

--- a/package-lock.json
+++ b/package-lock.json
@@ -3036,6 +3036,16 @@
       "integrity": "sha1-j0dAiy1oCxIm/9IF1QH499XikgY=",
       "requires": {
         "prom-client": "^10.0.0"
+      },
+      "dependencies": {
+        "prom-client": {
+          "version": "10.2.3",
+          "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-10.2.3.tgz",
+          "integrity": "sha512-Xboq5+TdUwuQtSSDRZRNnb5NprINlgQN999VqUjZxnLKydUNLeIPx6Eiahg6oJua3XBg2TGnh5Cth1s4I6+r7g==",
+          "requires": {
+            "tdigest": "^0.1.1"
+          }
+        }
       }
     },
     "equal-length": {
@@ -7883,9 +7893,9 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="
     },
     "prom-client": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-10.2.2.tgz",
-      "integrity": "sha512-d3qCBK41qZx00/WVzWOX4tau9FinCztqaECZiGuMI5vGYD//5VSdKMOZPRQKjVh5RkI4Ex98DI0YPsoFnEo1QQ==",
+      "version": "11.5.3",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-11.5.3.tgz",
+      "integrity": "sha512-iz22FmTbtkyL2vt0MdDFY+kWof+S9UB/NACxSn2aJcewtw+EERsen0urSkZ2WrHseNdydsvcxCTAnPcSMZZv4Q==",
       "requires": {
         "tdigest": "^0.1.1"
       }

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "node-anonize2-relic": "0.1.6",
     "node-slack": "0.0.7",
     "pg": "^7.9.0",
-    "prom-client": "10.2.2",
+    "prom-client": "11.5.3",
     "proxy-agent": "^2.3.1",
     "redis": "^2.8.0",
     "rsmq": "^0.8.2",


### PR DESCRIPTION
fixes #666 

tested by temporarily scaling docker `ledger-web` container and tweaking label in config.js to use `process.env.HOSTNAME`
```
http_request_duration_milliseconds{quantile="0.01",method="get",path="/favicon.ico",cardinality="one",status="200",dyno="ledger.7d0d1329858c"} 12
http_request_duration_milliseconds{quantile="0.05",method="get",path="/favicon.ico",cardinality="one",status="200",dyno="ledger.7d0d1329858c"} 12
http_request_duration_milliseconds{quantile="0.5",method="get",path="/favicon.ico",cardinality="one",status="200",dyno="ledger.7d0d1329858c"} 22
http_request_duration_milliseconds{quantile="0.9",method="get",path="/favicon.ico",cardinality="one",status="200",dyno="ledger.7d0d1329858c"} 28
http_request_duration_milliseconds{quantile="0.95",method="get",path="/favicon.ico",cardinality="one",status="200",dyno="ledger.7d0d1329858c"} 28
http_request_duration_milliseconds{quantile="0.99",method="get",path="/favicon.ico",cardinality="one",status="200",dyno="ledger.7d0d1329858c"} 28
http_request_duration_milliseconds{quantile="0.999",method="get",path="/favicon.ico",cardinality="one",status="200",dyno="ledger.7d0d1329858c"} 28
http_request_duration_milliseconds_sum{method="get",path="/favicon.ico",cardinality="one",status="200",dyno="ledger.7d0d1329858c"} 62
http_request_duration_milliseconds_count{method="get",path="/favicon.ico",cardinality="one",status="200",dyno="ledger.7d0d1329858c"} 3
http_request_duration_milliseconds{quantile="0.01",method="get",path="/metrics",cardinality="one",status="200",dyno="ledger.8277886de894"} 15
http_request_duration_milliseconds{quantile="0.05",method="get",path="/metrics",cardinality="one",status="200",dyno="ledger.8277886de894"} 15
http_request_duration_milliseconds{quantile="0.5",method="get",path="/metrics",cardinality="one",status="200",dyno="ledger.8277886de894"} 24
http_request_duration_milliseconds{quantile="0.9",method="get",path="/metrics",cardinality="one",status="200",dyno="ledger.8277886de894"} 39.599999999999994
http_request_duration_milliseconds{quantile="0.95",method="get",path="/metrics",cardinality="one",status="200",dyno="ledger.8277886de894"} 44
http_request_duration_milliseconds{quantile="0.99",method="get",path="/metrics",cardinality="one",status="200",dyno="ledger.8277886de894"} 44
http_request_duration_milliseconds{quantile="0.999",method="get",path="/metrics",cardinality="one",status="200",dyno="ledger.8277886de894"} 44
```