### PR TITLE
Fix ads payout report generation

### DIFF
--- a/eyeshade/migrations/0009_unique_payment_ids/down.sql
+++ b/eyeshade/migrations/0009_unique_payment_ids/down.sql
@@ -1,0 +1,9 @@
+select execute($$
+
+delete from migrations where id = '0009';
+
+alter table potential_payments_ads
+  drop constraint unique_payment_id_payout_report_id;
+
+$$) where exists (select * from migrations where id = '0009');
+

--- a/eyeshade/migrations/0009_unique_payment_ids/up.sql
+++ b/eyeshade/migrations/0009_unique_payment_ids/up.sql
@@ -6,4 +6,3 @@ alter table potential_payments_ads
   add constraint unique_payment_id_payout_report_id unique(payment_id, payout_report_id);
 
 $$) where not exists (select * from migrations where id = '0009');
-

--- a/eyeshade/migrations/0009_unique_payment_ids/up.sql
+++ b/eyeshade/migrations/0009_unique_payment_ids/up.sql
@@ -1,0 +1,9 @@
+select execute($$
+
+insert into migrations (id, description) values ('0009', 'unique_payment_ids');
+
+alter table potential_payments_ads
+  add constraint unique_payment_id_payout_report_id unique(payment_id, payout_report_id);
+
+$$) where not exists (select * from migrations where id = '0009');
+

--- a/eyeshade/workers/ads.js
+++ b/eyeshade/workers/ads.js
@@ -4,7 +4,21 @@ const underscore = require('underscore')
 
 const createPayoutReportQuery = `insert into payout_reports_ads (id) values ($1)`
 
-const selectWalletBalancesQuery = `select account_id, balance from account_balances where account_type = 'payment_id'`
+const selectWalletBalancesQuery = `
+  with ads_balances as (
+    select
+      account_id,
+      sum(amount) as balance,
+    from account_transactions
+    where account_type = 'payment_id'
+    and created_at < date_trunct('month', current_date)
+  )
+  select
+    account_id,
+    balance
+  from ads_balances
+  where balance > 0
+`
 
 const createPotentialPaymentsQuery = `insert into potential_payments_ads (payout_report_id, payment_id, provider_id, amount) values ($1, $2, $3, $4)`
 

--- a/eyeshade/workers/ads.js
+++ b/eyeshade/workers/ads.js
@@ -12,6 +12,8 @@ const selectWalletBalancesQuery = `
     from account_transactions
     where account_type = 'payment_id'
     and created_at < date_trunc('month', current_date)
+    group by account_id
+    order by balance desc
   )
   select
     account_id,

--- a/eyeshade/workers/ads.js
+++ b/eyeshade/workers/ads.js
@@ -27,6 +27,8 @@ const createPotentialPaymentsQuery = `insert into potential_payments_ads (payout
 // Takes a snapshot of ad account balances
 // and inserts them into potential_payments
 const monthly = async (debug, runtime) => {
+  // Limit the dynos that can run this worker to 1
+  if ((typeof process.env.DYNO !== 'undefined') && (process.env.DYNO !== 'worker.1')) return
   const client = await runtime.postgres.connect()
   const walletsCollection = runtime.database.get('wallets', debug)
   const payoutReportId = uuidV4()

--- a/eyeshade/workers/ads.js
+++ b/eyeshade/workers/ads.js
@@ -11,7 +11,7 @@ const selectWalletBalancesQuery = `
       sum(amount) as balance,
     from account_transactions
     where account_type = 'payment_id'
-    and created_at < date_trunct('month', current_date)
+    and created_at < date_trunc('month', current_date)
   )
   select
     account_id,

--- a/eyeshade/workers/ads.js
+++ b/eyeshade/workers/ads.js
@@ -27,8 +27,6 @@ const createPotentialPaymentsQuery = `insert into potential_payments_ads (payout
 // Takes a snapshot of ad account balances
 // and inserts them into potential_payments
 const monthly = async (debug, runtime) => {
-  // Limit the dynos that can run this worker to 1
-  if ((typeof process.env.DYNO !== 'undefined') && (process.env.DYNO !== 'worker.1')) return
   const client = await runtime.postgres.connect()
   const walletsCollection = runtime.database.get('wallets', debug)
   const payoutReportId = uuidV4()
@@ -55,6 +53,9 @@ const monthly = async (debug, runtime) => {
 }
 
 exports.initialize = async (debug, runtime) => {
+  // Limit the dynos that can run this worker to 1
+  if ((typeof process.env.DYNO !== 'undefined') && (process.env.DYNO !== 'worker.1')) return
+
   const interval = cron.parseExpression('0 0 1 * *', {})
   const next = interval.next().getTime()
   setTimeout(() => { monthly(debug, runtime) }, next - underscore.now())

--- a/eyeshade/workers/ads.js
+++ b/eyeshade/workers/ads.js
@@ -8,7 +8,7 @@ const selectWalletBalancesQuery = `
   with ads_balances as (
     select
       account_id,
-      sum(amount) as balance,
+      sum(amount) as balance
     from account_transactions
     where account_type = 'payment_id'
     and created_at < date_trunc('month', current_date)

--- a/test/eyeshade/ads.integration.test.js
+++ b/test/eyeshade/ads.integration.test.js
@@ -34,12 +34,11 @@ test('ads payout report cron job takes a snapshot of balances', async t => {
   const paymentId = uuidV4()
   const providerId = uuidV4()
   await wallets.insert({ paymentId, providerId })
-  const insertedWallet = await wallets.findOne({ paymentId: paymentId })
 
   // Create an ad transaction so there is a payment_id with a balance
   const txId = uuidV4()
   const createdAt = new Date()
-  createdAt.setMonth(createdAt.getMonth() - 2 )
+  createdAt.setMonth(createdAt.getMonth() - 2)
   const description = 'funding tx for viewing ads'
   const transactionType = 'ad'
   const fromAccountType = 'uphold'

--- a/test/eyeshade/ads.integration.test.js
+++ b/test/eyeshade/ads.integration.test.js
@@ -35,12 +35,11 @@ test('ads payout report cron job takes a snapshot of balances', async t => {
   const providerId = uuidV4()
   await wallets.insert({ paymentId, providerId })
   const insertedWallet = await wallets.findOne({ paymentId: paymentId })
-  console.log('inserted wallet is')
-  console.log(insertedWallet)
 
   // Create an ad transaction so there is a payment_id with a balance
   const txId = uuidV4()
   const createdAt = new Date()
+  createdAt.setMonth(createdAt.getMonth() - 2 )
   const description = 'funding tx for viewing ads'
   const transactionType = 'ad'
   const fromAccountType = 'uphold'


### PR DESCRIPTION
Resolves #678 

Builds on https://github.com/brave-intl/bat-ledger/pull/610

The first commit fixes two things about the query that selects the balances to be converted into ads potential payments

1. Adds an extra constraint that the balance is greater than 0. This is a constraint on the potential_payments table, this needs to be true anyway or else the entire transaction will be aborted (which we've seen on prod).

2. This ensures that we are only paying out transactions up to the first moment of the first of the month. All balances will be taken at the same time.


The second commit adds extra constraints to the potential_payments_ads table.  I added this to target a problem that I later realized we aren't having, but it would be good to add anyway.