### PR TITLE
Automatically add balancing transactions when uploading ads grants

### DIFF
--- a/eyeshade/workers/ads.js
+++ b/eyeshade/workers/ads.js
@@ -43,3 +43,17 @@ exports.initialize = async (debug, runtime) => {
 }
 
 exports.monthly = monthly
+
+exports.workers = {
+/* sent by ledger POST /v4/grants
+ */
+  'settlement-report-ads':
+    async (debug, runtime, payload) => {
+      const { postgres } = runtime
+
+      // TODO
+      // for each of the providerId, amount pairs
+      // that we made grants available
+      // insert the transactions into the eyeshade postgres
+    }
+}

--- a/ledger/controllers/grants.js
+++ b/ledger/controllers/grants.js
@@ -990,7 +990,7 @@ function uploadTypedGrants (protocolVersion, uploadSchema, contentSchema) {
       }
       promotionCounts[promotionId]++
     }
-
+    
     await grants.insert(grantsToInsert)
 
     for (let entry of payload.promotions) {
@@ -1007,6 +1007,14 @@ function uploadTypedGrants (protocolVersion, uploadSchema, contentSchema) {
         promotionId
       }, state, { upsert: true })
     }
+
+    // TODO
+    // initiate an ads-settlement-report
+    // with the uploaded grants
+    // with the payload
+    // 
+    // check if the type of the grants are ads
+    // await runtime.queue.send(debug, 'settlement-report-ads', { payload })
 
     reply({})
   }

--- a/test/ledger/grants.integration.test.js
+++ b/test/ledger/grants.integration.test.js
@@ -123,6 +123,7 @@ test('claim grants with attestations', async (t) => {
       minimumReconcileTimestamp: 1526941400000
     }]
   }
+
   await ledgerAgent.post(url).send(adGrants).expect(ok)
   await ledgerAgent.post(url).send(grants).expect(ok)
 


### PR DESCRIPTION
Resolves #679 

The proposed behavior is such: when the ads grants are signed and uploaded, pass a message to the shared redis queue.  The message is picked up by an eyeshade worker and the transaction is automatically inserted.

One problem is that grants are not active by default.  We should really only be inserting transactions for active grants.