### PR TITLE
reset metric on process first retreieve

### DIFF
--- a/bat-utils/lib/runtime-prometheus.js
+++ b/bat-utils/lib/runtime-prometheus.js
@@ -356,7 +356,7 @@ async function pullSettlementWalletBalanceMetrics (runtime) {
   // increment counter
   metric.inc(+delta)
   // cache currently known balance
-  await prometheus.cache().setAsync([settlementBalanceKey, currentBalance.toString(), 'EX', 60 * 60])
+  await prometheus.cache().setAsync([settlementBalanceKey, currentBalance.toString(), 'EX', 60])
 }
 
 async function getSettlementBalance (runtime) {

--- a/bat-utils/lib/runtime-prometheus.js
+++ b/bat-utils/lib/runtime-prometheus.js
@@ -7,8 +7,8 @@ const debug = new SDebug('prometheus')
 const listenerPrefix = `listeners:prometheus:`
 const listenerChannel = `${listenerPrefix}${process.env.SERVICE}`
 let registerMetricsPerProcess = registerMetrics
-
 const settlementBalanceKey = 'settlement:balance'
+const resetMetricOnce = _.once((runtime) => runtime.prometheus.cache().delAsync(settlementBalanceKey))
 
 module.exports = Prometheus
 
@@ -342,6 +342,7 @@ async function updateSettlementWalletMetrics (runtime) {
 
 async function pullSettlementWalletBalanceMetrics (runtime) {
   const { prometheus } = runtime
+  await resetMetricOnce(runtime)
   const metric = prometheus.getMetric('funds_received_count')
   const currentBalance = await getSettlementBalance(runtime)
   const lastBalanceCached = await prometheus.cache().getAsync(settlementBalanceKey)


### PR DESCRIPTION
reset metric on start

when checking the metrics i found that the votes and settlement count was way off. realized that the pr did not account for shutting down and starting back up for the cached settlement value but the rest of the metrics are.