### PR TITLE
split apart settlement to mitigate timeouts

### DIFF
--- a/bat-utils/lib/hapi-server.js
+++ b/bat-utils/lib/hapi-server.js
@@ -135,6 +135,7 @@ async function Server (options, runtime) {
       const bearerAccessTokenConfig = {
         allowQueryToken: true,
         allowMultipleHeaders: false,
+        allowChaining: true,
         validate: (request, token, h) => {
           const scope = ['devops', 'ledger', 'QA']
           const tokenlist = process.env.TOKEN_LIST ? process.env.TOKEN_LIST.split(',') : []
@@ -161,6 +162,7 @@ async function Server (options, runtime) {
   server.auth.strategy('simple-scoped-token', 'bearer-access-token', {
     allowQueryToken: true,
     allowMultipleHeaders: false,
+    allowChaining: true,
     validate: (request, token, h) => {
       const scope = pushScopedTokens(token)
       const isValid = !!scope.length

--- a/bat-utils/lib/hapi-server.js
+++ b/bat-utils/lib/hapi-server.js
@@ -118,6 +118,7 @@ async function Server (options, runtime) {
       debug('github authentication: forceHttps=' + github.isSecure)
 
       server.auth.strategy('session', 'cookie', {
+        redirectTo: '/v1/login',
         cookie: {
           password: github.ironKey,
           isSecure: github.isSecure
@@ -230,11 +231,6 @@ async function Server (options, runtime) {
     if ((!response.isBoom) || (response.output.statusCode !== 401)) {
       if (typeof response.header === 'function') response.header('Cache-Control', 'private')
       return h.continue
-    }
-
-    if (request && request.auth && request.cookieAuth && request.cookieAuth.clear) {
-      request.cookieAuth.clear()
-      return h.redirect('/v1/login')
     }
 
     return h.continue

--- a/eyeshade/controllers/publishers.js
+++ b/eyeshade/controllers/publishers.js
@@ -78,11 +78,9 @@ v2.settlement = {
           entries = []
           settlementGroups[type] = entries
         }
-        entries.push(settlementId)
-      }
-
-      for (let type in settlementGroups) {
-        settlementGroups[type] = underscore.uniq(settlementGroups[type])
+        if (!entries.includes(settlementId)) {
+          entries.push(settlementId)
+        }
       }
 
       return settlementGroups

--- a/eyeshade/controllers/publishers.js
+++ b/eyeshade/controllers/publishers.js
@@ -88,7 +88,7 @@ v2.settlement = {
   },
 
   auth: {
-    strategies: ['session', 'simple-scoped-token'],
+    strategies: ['simple-scoped-token', 'session'],
     scope: ['ledger', 'publishers'],
     mode: 'required'
   },
@@ -141,7 +141,7 @@ v2.submitSettlement = {
   },
 
   auth: {
-    strategies: ['session', 'simple-scoped-token'],
+    strategies: ['simple-scoped-token', 'session'],
     scope: ['ledger', 'publishers'],
     mode: 'required'
   },
@@ -161,8 +161,8 @@ v2.submitSettlement = {
 }
 
 module.exports.routes = [
-  braveHapi.routes.async().post().path('/v2/publishers/settlement').config(v2.settlement),
-  braveHapi.routes.async().post().path('/v2/publishers/settlement/submit').config(v2.submitSettlement)
+  braveHapi.routes.async().post().path('/v2/publishers/settlement/submit').config(v2.submitSettlement),
+  braveHapi.routes.async().post().path('/v2/publishers/settlement').config(v2.settlement)
 ]
 
 module.exports.initialize = async (debug, runtime) => {

--- a/test/e2e.integration.test.js
+++ b/test/e2e.integration.test.js
@@ -245,7 +245,8 @@ test('ledger : user contribution workflow with uphold BAT wallet', async t => {
     executedAt: newYear.toISOString()
   })
 
-  await eyeshadeAgent.post(settlementURL).send([settlement]).expect(ok)
+  response = await eyeshadeAgent.post(settlementURL).send([settlement]).expect(ok)
+  await eyeshadeAgent.post(settlementURL + '/submit').send(response.body).expect(ok)
   do {
     await timeout(5000)
     await updateBalances(runtime)

--- a/test/eyeshade/publishers.integration.test.js
+++ b/test/eyeshade/publishers.integration.test.js
@@ -47,8 +47,8 @@ test('cannot post payouts if the publisher field is blank and type is not manual
     hash: uuidV4().toLowerCase()
   }
 
-  const reponse = await eyeshadeAgent.post(url).send([manualSettlement])
-  t.true(reponse.status === 400)
+  const response = await eyeshadeAgent.post(url).send([manualSettlement])
+  t.true(response.status === 400)
 })
 
 test('can post a manual settlement from publisher app using token auth', async t => {
@@ -74,7 +74,8 @@ test('can post a manual settlement from publisher app using token auth', async t
     hash: uuidV4().toLowerCase()
   }
 
-  await eyeshadeAgent.post(url).send([manualSettlement]).expect(200)
+  const response = await eyeshadeAgent.post(url).send([manualSettlement]).expect(200)
+  await eyeshadeAgent.post(url + '/submit').send(response.body).expect(200)
 
   // ensure the manual settlement doc was created with the document id
   const settlementDoc = await settlements.findOne({ settlementId: manualSettlement.transactionId })
@@ -191,6 +192,6 @@ test('only can post settlement files under to 20mbs', async t => {
   t.true(response.body.message === 'Payload content length greater than maximum allowed: 20971520')
 
   // ensure small settlement files succeed
-  response = await eyeshadeAgent.post(url).send([smallSettlement])
-  t.true(response.statusCode === 200)
+  response = await eyeshadeAgent.post(url).send([smallSettlement]).expect(200)
+  response = await eyeshadeAgent.post(url + '/submit').send(response.body).expect(200)
 })


### PR DESCRIPTION
tested by splitting apart settlement
```bash
curl -v -X POST -d "@./referrals-clean-signed-finished.json" -H "Content-Type: application/json" -H "Authorization: Bearer foobarfoobar" "http://localhost:3002/v2/publishers/settlement"

curl -v -X POST -d "@./referrals-clean-signed-finished-2.json" -H "Content-Type: application/json" -H "Authorization: Bearer foobarfoobar" "http://localhost:3002/v2/publishers/settlement"

# manual merge
curl -v -X POST -d '{"referral":["d7cd33c0-66b6-4e27-ae83-9f1f11520af8"]}' -H "Content-Type: application/json" -H "Authorization: Bearer foobarfoobar" "http://localhost:3002/v2/publishers/settlement/submit"
```