### PR TITLE
throw on fail to restore verbose joi errors

### DIFF
--- a/bat-utils/lib/hapi-server.js
+++ b/bat-utils/lib/hapi-server.js
@@ -54,7 +54,14 @@ async function Server (options, runtime) {
 
   const serverOpts = {
     port: options.port,
-    host: '0.0.0.0'
+    host: '0.0.0.0',
+    routes: {
+      validate: {
+        failAction: async (request, h, err) => {
+          throw err
+        }
+      }
+    }
   }
   const server = new hapi.Server(serverOpts)
 


### PR DESCRIPTION
hapi / joi changed the default behavior when schema validation fails, this restore the previous default of including information about the particular failures:
https://futurestud.io/tutorials/hapi-v17-upgrade-guide-your-move-to-async-await#updatefailaction