### PR TITLE
include the anonymousAddress in the wallet info endpoint

### DIFF
--- a/ledger/controllers/wallet.js
+++ b/ledger/controllers/wallet.js
@@ -54,7 +54,7 @@ v2.readInfo = { handler: (runtime) => {
       throw boom.notFound('no such wallet: ' + paymentId)
     }
 
-    const infoKeys = [ 'addresses', 'altcurrency', 'provider', 'providerId', 'paymentId', 'httpSigningPubKey' ]
+    const infoKeys = [ 'addresses', 'altcurrency', 'provider', 'providerId', 'paymentId', 'httpSigningPubKey', 'anonymousAddress' ]
     return underscore.pick(wallet, infoKeys)
   }
 },


### PR DESCRIPTION
We need to expose it in order for the endpoint on the grant server that allows claiming virtual grant ad earnings to transfer funds to it.