### PR TITLE
reduce load from freezing votes (#843)

### DIFF
--- a/eyeshade/workers/surveyors.js
+++ b/eyeshade/workers/surveyors.js
@@ -77,6 +77,13 @@ exports.workers = {
         if (shouldUpdateBalances) {
           await updateBalances(runtime)
         }
+      } catch (e) {
+        runtime.captureException(e, {
+          extra: {
+            surveyorId
+          }
+        })
+        throw e
       } finally {
         client.release()
       }

--- a/test/ledger/surveyor.integration.test.js
+++ b/test/ledger/surveyor.integration.test.js
@@ -60,11 +60,6 @@ test('verify surveyor sends back choices', async t => {
   for (let i = 0; i < choices.USD.length; i += 1) {
     t.true(_.isNumber(choices.USD[i]), 'each item is a number')
   }
-  /*
-  {
-    USD: [20, 35, 50, 85]
-  }
-  */
 
   function checkResponse (response, expectation) {
     const { body } = response


### PR DESCRIPTION
takes its time to freeze surveyor votes and refreshes balances at the end so that we don't get db errors.