### PR TITLE
reverted to joi16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5588,11 +5588,10 @@
       }
     },
     "joi": {
-      "version": "17.1.1",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.1.1.tgz",
-      "integrity": "sha512-fww3Ae9cRyj6yHy90cpxvL2y39V5JCY2KaXV3KfALhoFfFcAuyQBPOq+2q6EZ2QNMn1FhkDy+eRkGVG7J+BvyA==",
+      "version": "github:sideway/joi#8091cc15005c3c613d378e07c5d39de9e5bfb5fd",
+      "from": "github:sideway/joi#8091cc15005c3c613d378e07c5d39de9e5bfb5fd",
       "requires": {
-        "@hapi/address": "^4.0.1",
+        "@hapi/address": "^4.1.0",
         "@hapi/formula": "^2.0.0",
         "@hapi/hoek": "^9.0.0",
         "@hapi/pinpoint": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "hapi-auth-bearer-token": "^6.1.4",
     "hapi-require-https": "^4.0.0",
     "http-request-signature": "0.0.3",
-    "joi": "^17.1.1",
+    "joi": "github:sideway/joi#8091cc15005c3c613d378e07c5d39de9e5bfb5fd",
     "moment": "^2.22.1",
     "mongodb": "^3.5.4",
     "monk": "^7.1.2",


### PR DESCRIPTION
in order to reduce extra errors, the decision was made to revert back to the original version since the problem was that the dependency could not be found. not that it needed an upgrade