### PR TITLE
allowed partition constraint to be passed

### DIFF
--- a/bat-utils/lib/runtime-kafka.js
+++ b/bat-utils/lib/runtime-kafka.js
@@ -75,12 +75,14 @@ class Kafka {
     consumers.push(consumer)
   }
 
-  async sendMany ({ topic, encode }, messages) {
+  async sendMany ({ topic, encode }, messages, _partition = null, _key = null, _partitionKey = null) {
     // map twice to err quickly on input errors
     // use map during send to increase batching on network
     return Promise.all(
       messages.map(encode)
-        .map((msg) => this.send(topic, msg))
+        .map((msg) =>
+          this.send(topic, msg, _partition, _key, _partitionKey)
+        )
     )
   }
 

--- a/bin/migrate-mongo-to-kafka.js
+++ b/bin/migrate-mongo-to-kafka.js
@@ -138,7 +138,7 @@ async function connectToKafka (collectionName, key, coder, transformForKafka) {
     }
     // check for any buffer errors
     console.log('sending many', collectionName, targetId, messages.length)
-    await runtime.kafka.sendMany(coder, messages)
+    await runtime.kafka.sendMany(coder, messages, 1)
     console.log('setting migrated', collectionName, targetId)
     await collection.update({
       [key]: targetId
@@ -147,10 +147,6 @@ async function connectToKafka (collectionName, key, coder, transformForKafka) {
     }, {
       multi: true
     })
-    // first tests showed ~900/second
-    const ms = messages.length * (1000 / 900)
-    console.log('waiting', ms)
-    await new Promise((resolve) => setTimeout(resolve, ms))
   }
 }
 


### PR DESCRIPTION
in order to not block the current stream of messages going by we created a second partition to add old messages to so that they can be processed as throughput is available