### PR TITLE
added redis connection string building when password is set

### DIFF
--- a/config.js
+++ b/config.js
@@ -39,6 +39,11 @@ if (!service) {
 }
 
 process.env.PORT = process.env.PORT  || service.portno
+let redisURL = process.env.REDIS_URL
+const redisPass = process.env.REDIS_PASSWORD
+if (redisPass) {
+  redisURL = `redis://user:${redisPass}@${process.env.REDIS_MASTER_SERVICE_HOST_REDIS}:${process.env.REDIS_MASTER_SERVICE_PORT_REDIS}`
+}
 
 module.exports =
 {
@@ -77,14 +82,14 @@ module.exports =
   altcurrency           : process.env.ALTCURRENCY               || 'BAT'
 , cache                 :
   { redis               :
-    { url               : process.env.REDIS_URL                 || 'redis://localhost:6379' }
+    { url               : redisURL                 || 'redis://localhost:6379' }
   }
 , currency              :
   { altcoins            : process.env.CRYPTO_CURRENCIES ? process.env.CRYPTO_CURRENCIES.split(',')
                                                         : [ 'BAT', 'BTC', 'ETH', 'LTC' ] }
 , login                 : { github: false }
 , queue                 :
-  { rsmq                : process.env.REDIS_URL                 || 'redis://localhost:6379' }
+  { rsmq                : redisURL                 || 'redis://localhost:6379' }
 , sentry                :
   { dsn: process.env.SENTRY_DSN          || false
   , slug: process.env.HEROKU_SLUG_COMMIT || 'test'
@@ -146,5 +151,5 @@ if (process.env.KAFKA_BROKERS) {
 
 module.exports.prometheus =
   { label              : process.env.SERVICE + '.' + (process.env.DYNO || 1)
-  , redis              : process.env.REDIS2_URL               || process.env.REDIS_URL               ||  false
+  , redis              : process.env.REDIS2_URL               || redisURL               ||  false
   }

--- a/config.js
+++ b/config.js
@@ -42,7 +42,7 @@ process.env.PORT = process.env.PORT  || service.portno
 let redisURL = process.env.REDIS_URL
 const redisPass = process.env.REDIS_PASSWORD
 if (redisPass) {
-  redisURL = `redis://user:${redisPass}@${process.env.REDIS_MASTER_SERVICE_HOST_REDIS}:${process.env.REDIS_MASTER_SERVICE_PORT_REDIS}`
+  redisURL = `redis://user:${encodeURIComponent(redisPass)}@${process.env.REDIS_MASTER_SERVICE_HOST_REDIS}:${process.env.REDIS_MASTER_SERVICE_PORT_REDIS}`
 }
 
 module.exports =

--- a/eyeshade/controllers/referrals.js
+++ b/eyeshade/controllers/referrals.js
@@ -16,9 +16,7 @@ const amountValidator = braveJoi.string().numeric()
 const groupNameValidator = Joi.string().optional().description('the name given to the group')
 const publisherValidator = braveJoi.string().publisher().allow(null, '').optional().description('the publisher identity. e.g. youtube#VALUE, twitter#VALUE, reddit#value, etc., or null.  owner aka publishers#VALUE should not go here')
 const currencyValidator = braveJoi.string().altcurrencyCode().description('the currency unit being paid out')
-const groupIdValidator = Joi.string().guid().description('the region from which this referral came')
 const countryCodeValidator = braveJoi.string().countryCode().allow('OT').description('a country code in iso 3166 format').example('CA')
-const referralCodeValidator = Joi.string().required().description('the referral code tied to the referral')
 
 const referral = Joi.object().keys({
   ownerId: braveJoi.string().owner().required().description('the owner'),
@@ -135,7 +133,6 @@ v1.getReferralGroups = {
 /*
   GET /v1/referrals/statement/{owner}
 */
-
 
 v1.getReferralsStatement = {
   handler: () => async () => {


### PR DESCRIPTION
if `REDIS_PASSWORD` is available as in the case of the k8s cluster, we need to dynamically build the string because we cannot do so in the yaml files in the eyeshade-ops repo