### PR TITLE
updated npm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update && apt-get install -y postgresql-client
 RUN mkdir -p /usr/src/app && mkdir /usr/src/app/bat-utils
 WORKDIR /usr/src/app
 
-RUN npm install -g npm@6.11.3
+RUN npm install -g npm@5.10.0
 
 COPY package.json /usr/src/app/
 COPY bat-utils/package.json /usr/src/app/bat-utils/


### PR DESCRIPTION
having too high a version was causing issues when deploying onto k8s
downgraded the version and while we are still at a higher version, it at least no longer errs