### PR TITLE
removed include migration

### DIFF
--- a/eyeshade/migrations/0017_include_indexes/down.sql
+++ b/eyeshade/migrations/0017_include_indexes/down.sql
@@ -1,6 +1,6 @@
 select execute($$
 
-DROP INDEX IF EXISTS transactions_with_type_filter_idx;
+-- DROP INDEX IF EXISTS transactions_with_type_filter_idx;
 
 delete from migrations where id = '0017';
 

--- a/eyeshade/migrations/0017_include_indexes/up.sql
+++ b/eyeshade/migrations/0017_include_indexes/up.sql
@@ -2,8 +2,8 @@ select execute($$
 
 insert into migrations (id, description) values ('0017', 'include_indexes');
 
-CREATE INDEX transactions_with_type_filter_idx
-ON transactions (from_account, to_account, transaction_type)
-INCLUDE (created_at, description, channel, amount, settlement_currency, settlement_amount);
+-- CREATE INDEX transactions_with_type_filter_idx
+-- ON transactions (from_account, to_account, transaction_type)
+-- INCLUDE (created_at, description, channel, amount, settlement_currency, settlement_amount);
 
 $$) where not exists (select * from migrations where id = '0017');


### PR DESCRIPTION
got the following error when running for new dbs: 
```
ERROR:  syntax error at or near "INCLUDE"
LINE 7: INCLUDE (created_at, description, channel, amount, settlemen...
        ^
QUERY:  
insert into migrations (id, description) values ('0017', 'include_indexes');
CREATE INDEX transactions_with_type_filter_idx
ON transactions (from_account, to_account, transaction_type)
INCLUDE (created_at, description, channel, amount, settlement_currency, settlement_amount);
```