### PR TITLE
Batch surveyor txs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,6 @@ name: CI
 # Controls when the action will run. Triggers the workflow on push or pull request
 # events but only for the master branch
 on:
-  workflow_dispatch:
-    inputs:
-      name: manual
   push:
     branches:
       - master

--- a/bat-utils/lib/runtime-postgres.js
+++ b/bat-utils/lib/runtime-postgres.js
@@ -85,6 +85,17 @@ Postgres.prototype = {
       length: params.length
     })
   },
+  prepInsert: function (rows) {
+    const filtered = rows.filter((row) => row)
+    const longest = filtered.reduce((memo, row) => row ? Math.max(row.length, memo) : memo, 0)
+    return filtered.map((row) => {
+      const newRow = new Array(longest)
+      row.forEach((arg, index) => {
+        newRow[index] = arg
+      })
+      return newRow
+    })
+  },
   transact: async function (fn) {
     const client = await this.connect()
     let res

--- a/bat-utils/lib/runtime-postgres.js
+++ b/bat-utils/lib/runtime-postgres.js
@@ -75,11 +75,12 @@ Postgres.prototype = {
     const values = 'values'
     if (query.slice(query.length - values.length).toLowerCase() === values) {
       // append row placeholders to the query
-      query = `${query} ${params.map((row, rowIndex) =>
+      const preppedParams = this.prepInsert(params)
+      query = `${query} ${preppedParams.map((row, rowIndex) =>
         `( ${row.map((_, argIndex) => `$${1 + argIndex + (row.length * rowIndex)}`).join(', ')} )`
       ).join(',\n')}${returnResults ? '\nreturning *' : ''}`
       // flatten the rows into a single array
-      args = [].concat.apply([], params)
+      args = [].concat.apply([], preppedParams)
     }
     return runQuery(query, args, client, {
       text,

--- a/bat-utils/lib/runtime-postgres.js
+++ b/bat-utils/lib/runtime-postgres.js
@@ -74,9 +74,9 @@ Postgres.prototype = {
     const values = 'values'
     if (query.slice(query.length - values.length).toLowerCase() === values) {
       // append row placeholders to the query
-      query = `${query} ${params.map((memo, row, rowIndex) => memo.concat(
+      query = `${query} ${params.map((row, rowIndex) =>
         `( ${row.map((_, argIndex) => `$${1 + argIndex + (row.length * rowIndex)}`).join(', ')} )`
-      ), []).join(',\n')}`
+      ).join(',\n')}`
       // flatten the rows into a single array
       args = [].concat.apply([], params)
     }

--- a/bat-utils/lib/runtime-postgres.js
+++ b/bat-utils/lib/runtime-postgres.js
@@ -87,7 +87,7 @@ Postgres.prototype = {
   },
   prepInsert: function (rows) {
     const filtered = rows.filter((row) => row)
-    const longest = filtered.reduce((memo, row) => row ? Math.max(row.length, memo) : memo, 0)
+    const longest = filtered.reduce((memo, row) => Math.max(row.length, memo), 0)
     return filtered.map((row) => {
       const newRow = new Array(longest)
       row.forEach((arg, index) => {

--- a/bat-utils/lib/runtime-postgres.test.js
+++ b/bat-utils/lib/runtime-postgres.test.js
@@ -32,36 +32,3 @@ test('executes queries', async (t) => {
   where id = $1`, [id])
   t.deepEqual(rows, gotten)
 })
-
-test('batching inserts', async (t) => {
-  const query = `insert into surveyor_groups (id, price, frozen, virtual)
-  values` // this is the important part
-  const rows = [...new Array(20)].map(() => ([
-    uuidV4(),
-    '0.25',
-    false,
-    true
-  ]))
-  const { rows: inserted } = await postgres.insert(query, rows, { returnResults: true })
-  const ids = rows.map((row) => row[0])
-  const { rows: gotten } = await postgres.query(`select * from surveyor_groups
-  where id = any($1::text[])`, [ids])
-  t.is(20, gotten.length)
-  t.deepEqual(inserted, gotten)
-})
-
-test('prepInsert', async (t) => {
-  const input = [
-    ['a'],
-    undefined,
-    ['b', 2],
-    null,
-    ['c', 3, uuidV4()]
-  ]
-  const transformed = postgres.prepInsert(input)
-  t.deepEqual(transformed, [
-    ['a', undefined, undefined],
-    ['b', 2, undefined],
-    ['c', 3, input[4][2]]
-  ])
-})

--- a/bat-utils/lib/runtime-postgres.test.js
+++ b/bat-utils/lib/runtime-postgres.test.js
@@ -1,0 +1,67 @@
+const test = require('ava')
+const _ = require('underscore')
+const Postgres = require('./runtime-postgres')
+const { v4: uuidV4 } = require('uuid')
+const dotenv = require('dotenv')
+dotenv.config()
+
+const postgres = new Postgres({
+  postgres: {
+    url: process.env.DATABASE_URL
+  }
+})
+
+test('instantiates correctly', (t) => {
+  t.true(_.isObject(postgres))
+})
+
+test('executes queries', async (t) => {
+  const id = uuidV4()
+  const { rows } = await postgres.query(`
+  insert into surveyor_groups (id, price, frozen, virtual)
+  values ($1, $2, $3, $4)
+  returning *`, [
+    id,
+    '0.25',
+    'false',
+    'true'
+  ])
+  t.is(rows.length, 1)
+  const { rows: gotten } = await postgres.query(`
+  select * from surveyor_groups
+  where id = $1`, [id])
+  t.deepEqual(rows, gotten)
+})
+
+test('batching inserts', async (t) => {
+  const query = `insert into surveyor_groups (id, price, frozen, virtual)
+  values` // this is the important part
+  const rows = [...new Array(20)].map(() => ([
+    uuidV4(),
+    '0.25',
+    false,
+    true
+  ]))
+  const { rows: inserted } = await postgres.insert(query, rows, { returnResults: true })
+  const ids = rows.map((row) => row[0])
+  const { rows: gotten } = await postgres.query(`select * from surveyor_groups
+  where id = any($1::text[])`, [ids])
+  t.is(20, gotten.length)
+  t.deepEqual(inserted, gotten)
+})
+
+test('prepInsert', async (t) => {
+  const input = [
+    ['a'],
+    undefined,
+    ['b', 2],
+    null,
+    ['c', 3, uuidV4()]
+  ]
+  const transformed = postgres.prepInsert(input)
+  t.deepEqual(transformed, [
+    ['a', undefined, undefined],
+    ['b', 2, undefined],
+    ['c', 3, input[4][2]]
+  ])
+})

--- a/eyeshade/lib/transaction.js
+++ b/eyeshade/lib/transaction.js
@@ -307,11 +307,7 @@ async function insertManyFromVoting (atOneTime, runtime, client, docs, surveyorC
     const query = `
     insert into transactions ( id, created_at, description, transaction_type, document_id, from_account, from_account_type, to_account, to_account_type, amount, channel )
     VALUES`
-    await runtime.postgres.insert(
-      query,
-      runtime.postgres.prepInsert(mapped),
-      client
-    )
+    await runtime.postgres.insert(query, mapped, { client })
   }
 }
 

--- a/eyeshade/lib/transaction.js
+++ b/eyeshade/lib/transaction.js
@@ -293,9 +293,9 @@ function insertFromVotingArguments (settlementAddress, voteDoc, surveyorCreatedA
   }
 }
 
-async function insertManyFromVoting (atOneTime, runtime, client, docs, surveyorCreatedAt) {
-  for (let i = 0; i < docs.length; i += atOneTime) {
-    const mapped = docs.slice(i, i + atOneTime).map((doc) =>
+async function insertManyFromVoting (batchSize, runtime, client, docs, surveyorCreatedAt) {
+  for (let i = 0; i < docs.length; i += batchSize) {
+    const mapped = docs.slice(i, i + batchSize).map((doc) =>
       insertFromVotingArguments(
         runtime.config.wallet.settlementAddress.BAT,
         doc,

--- a/eyeshade/workers/surveyors.js
+++ b/eyeshade/workers/surveyors.js
@@ -1,4 +1,4 @@
-const { insertFromVoting } = require('../lib/transaction.js')
+const { insertMany } = require('../lib/transaction.js')
 
 const feePercent = 0.05
 
@@ -35,18 +35,8 @@ exports.surveyorFrozenReport = async (debug, runtime, payload) => {
     if (!votingQ.rowCount) {
       throw new Error('no votes for this surveyor!')
     }
-    const docs = votingQ.rows
     try {
-      let inserting = []
-      for (let i = 0; i < docs.length; i += 1) {
-        const inserted = insertFromVoting(runtime, client, Object.assign(docs[i], { surveyorId }), surveyorCreatedAt)
-        inserting.push(inserted)
-        if (inserting.length >= 25) {
-          await Promise.all(inserting)
-          inserting = []
-        }
-      }
-      await Promise.all(inserting)
+      await insertMany.fromVoting(25, runtime, client, votingQ.rows, surveyorCreatedAt)
 
       const markVotesTransactedStatement = `
       update votes

--- a/package-lock.json
+++ b/package-lock.json
@@ -6095,6 +6095,11 @@
       "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-0.1.3.tgz",
       "integrity": "sha1-2hhHsglA5C7hSSvq9l1J2RskXfc="
     },
+    "pg-format": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/pg-format/-/pg-format-1.0.4.tgz",
+      "integrity": "sha1-J3NCNsKtP05QZJFaWTNOIAQKgo4="
+    },
     "pg-int8": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "newrelic": "^4.1.1",
     "nyc": "^15.1.0",
     "pg": "^7.18.2",
+    "pg-format": "^1.0.4",
     "prom-client": "11.5.3",
     "proxy-agent": "^2.3.1",
     "queue-microtask": "github:brave-intl/queue-microtask#master",


### PR DESCRIPTION
- refactor postgres code to treat inserts differently
- insert batches of transactions at the same time
- dynamically generate the query string and flatten arguments

currently a single surveyor with 4000 publishers, takes about 10 minutes to complete just the transaction insertion part.
the main cause of this is the round trip that the client does with each query. even making method calls concurrent, does not mitigate this as there is an internal mechanism for serially executing the queries. to get around this, the ability to add many transactions (only for voting for now) in a foolproof manner was added. this should bring the theoretical execution time down to about 24 seconds for this portion of the code (inserting transactions) since we are almost exclusively bottlenecked by the ordering of transactions going back and forth to the db.

some code snippets you can try yourself

pre allocated arrays do not compact
```
> const a = new Array(4)
> const b = new Array(4)
> [].concat.apply([], a)
[ undefined, undefined, undefined, undefined ]
> [].concat.apply([], [a,b])
[ <8 empty items> ]
```

get the end of a string
```
> 'batches'.slice('batches'.length - 2)
'es'
```

values section of query is generated correctly
```
> [['a', 'id'],['b', 'id']].map((row, rowIndex) => 
   `( ${row.map((_, argIndex) => `$${1 + argIndex + (row.length * rowIndex)}`).join(', ')} )`
).join(',\n')
'( $1, $2 ),\n( $3, $4 )'
```

to see the queries used in tests, feel free to use
```bash
DEBUG=*postgres ./node_modules/.bin/ava ./test/eyeshade/transaction.integration.test.js -m "insert from many voting transaction"
# and
DEBUG=*postgres ./node_modules/.bin/ava ./bat-utils/lib/runtime-postgres.test.js
```