### PR TITLE
Fix date parsing in mapMessages

### DIFF
--- a/bat-utils/lib/runtime-kafka.js
+++ b/bat-utils/lib/runtime-kafka.js
@@ -108,7 +108,8 @@ class RuntimeKafka {
   async mapMessages ({ decode, topic }, messages, fn) {
     const results = []
     const msgs = messages.map((msg) => {
-      const { value, timestamp } = msg
+      let { value, timestamp } = msg
+      timestamp = parseInt(timestamp, 10)
       const buf = Buffer.from(value, 'binary')
       try {
         const { message } = decode(buf)

--- a/bat-utils/lib/runtime-kafka.test.js
+++ b/bat-utils/lib/runtime-kafka.test.js
@@ -18,6 +18,10 @@ test('can create kafka consumer', async (t) => {
   const consumer = new Kafka(runtime.config, runtime)
   const messagePromise = new Promise(resolve => {
     consumer.on('test-topic', async (messages) => {
+      await consumer.mapMessages({ topic: 'test-topic', decode: (_) => { return { message: 'hi!' } } }, messages, async (item, timestamp) => {
+        t.true(timestamp instanceof Date && !isNaN(timestamp))
+        return true
+      })
       resolve(Buffer.from(messages[0].value, 'binary').toString())
     })
   })


### PR DESCRIPTION
With the kafka library changes, we didn't notice that timestamps now come through as strings. We have to convert this to a number before passing to business logic.

We can run this DB query to fix records affected:

```sql
UPDATE transactions
SET created_at = inserted_at
WHERE created_at < '1970-05-01'
```